### PR TITLE
GESTALT-6921: Re-optimize Gestalt icon SVGs to support iOS usage

### DIFF
--- a/src/models/figma.ts
+++ b/src/models/figma.ts
@@ -79,6 +79,12 @@ export interface FigmaFile {
   mainFileKey: string;
 }
 
+export interface FigmaImages {
+  err?: string,
+  images: Record<string, string>, // Image ID -> Image URL
+  status?: number
+}
+
 export interface FigmaVersion {
   id: string;
   created_at: string;

--- a/src/webapi.ts
+++ b/src/webapi.ts
@@ -4,6 +4,7 @@ import axios from "axios";
 
 import {
   FigmaFile,
+  FigmaImages,
   FigmaPartialFile,
   FigmaSharedNode,
   FigmaTeamComponent,
@@ -61,6 +62,20 @@ export class FigmaAPIHelper {
       },
     });
     const data = resp.data as FigmaFile;
+    return data;
+  }
+
+  static async getImages(
+    fileKey: string,
+    imageIds: string[],
+    format: 'jpg' | 'png' | 'svg' | 'pdf'
+  ): Promise<FigmaImages> {
+    const resp = await axios.get(`${BASE_URL}/images/${fileKey}?format=${format}&ids=${imageIds.join(',')}`, {
+      headers: {
+        "X-FIGMA-TOKEN": FigmaAPIHelper.API_TOKEN,
+      },
+    });
+    const data = resp.data as FigmaImages;
     return data;
   }
 


### PR DESCRIPTION
* Added `getImages()` method to export SVGs (or other formats)