### PR TITLE
GESTALT-7139: Plugin doesn't lint ellipse stroke color styles

### DIFF
--- a/src/rules/fillStyle.ts
+++ b/src/rules/fillStyle.ts
@@ -20,10 +20,11 @@ export default function checkFillStyleMatch(
 ): LintCheck {
   // decrement the count, or increment depending on what we find
   const checkName = "Fill-Style";
+
   // check if correct Node Type
   if (
     !isNodeOfTypeAndVisible(
-      ["TEXT", "RECTANGLE", "ELLIPSE", "POLYGON", "INSTANCE"],
+      ["ELLIPSE", "INSTANCE", "POLYGON", "RECTANGLE", "STAR", "TEXT", "VECTOR"],
       targetNode
     )
   )

--- a/src/rules/strokeStyle.ts
+++ b/src/rules/strokeStyle.ts
@@ -18,7 +18,14 @@ export default function checkStrokeStyleMatch(
 ): LintCheck {
   // decrement the count, or increment depending on what we find
   const checkName = "Stroke-Fill-Style";
-  if (!isNodeOfTypeAndVisible(["RECTANGLE", "ELLISPE"], targetNode))
+
+  // check if correct Node Type
+  if (
+    !isNodeOfTypeAndVisible(
+      ["ELLIPSE", "INSTANCE", "POLYGON", "RECTANGLE", "STAR", "TEXT", "VECTOR"],
+      targetNode
+    )
+  )
     return { checkName, matchLevel: "Skip", suggestions: [] };
 
   // if a stroke doesn't exist in the first place, it's a skip


### PR DESCRIPTION
* Fix typo bug with "**ELLISPE**" that caused Strokes on ellipse layers to not be linted
* Normalized node types between Fill And Stroke style linting, and also adding `STAR` and `VECTOR` layer types to both

