### PR TITLE
Skip fill and stroke linting for nodes using color variables

### DIFF
--- a/src/rules/fillStyle.ts
+++ b/src/rules/fillStyle.ts
@@ -55,6 +55,13 @@ export default function checkFillStyleMatch(
     return { checkName, matchLevel: "Skip", suggestions: [] };
   }
 
+  // :TODO: Temp workaround until we properly support variable linting, fixing, and compliance calculations
+  // Ignore the node if any color variables are in-use
+  const colorVariables = jp.query(targetNode, "$.fills[*].boundVariables.color");
+  if (colorVariables.length > 0) {
+    return { checkName, matchLevel: "Skip", suggestions: [] };
+  }
+
   if (opts?.hexStyleMap) {
     const { hexStyleMap } = opts;
     const fillProps = getStyleLookupDefinitions("FILL");

--- a/src/rules/strokeStyle.ts
+++ b/src/rules/strokeStyle.ts
@@ -44,6 +44,13 @@ export default function checkStrokeStyleMatch(
       exactMatch: { key: exactMatch.key },
     };
 
+  // :TODO: Temp workaround until we properly support variable linting, fixing, and compliance calculations
+  // Ignore the node if any color variables are in-use
+  const colorVariables = jp.query(targetNode, "$.strokes[*].boundVariables.color");
+  if (colorVariables.length > 0) {
+    return { checkName, matchLevel: "Skip", suggestions: [] };
+  }
+
   if (opts?.hexStyleMap) {
     const { hexStyleMap } = opts;
     const strokeProps = getStyleLookupDefinitions("STROKE");


### PR DESCRIPTION
Temporarily skipping nodes using color variables until we implement and support variable color matching and linting