### PR TITLE
GESTALT-8371: Compliance Bug: Multiple Text Styles in on text field

### DIFF
--- a/src/rules/utils/styles/exact.ts
+++ b/src/rules/utils/styles/exact.ts
@@ -1,10 +1,14 @@
-import { FigmaStyleType, StyleBucket } from "../../../models/figma";
+import {
+  FigmaStyleType,
+  FigmaTeamStyle,
+  StyleBucket,
+} from "../../../models/figma";
 
 export const isExactStyleMatch = (
   styleType: FigmaStyleType | "STROKE",
   styleBucket: StyleBucket,
   targetNode: BaseNode
-) => {
+): FigmaTeamStyle | undefined => {
   // way the styles are represented varies based on runtime
   if (typeof figma !== "undefined") {
     return isExactStyleMatchInFigma(styleType, styleBucket, targetNode);
@@ -17,34 +21,53 @@ function isExactStyleMatchInFigma(
   styleType: FigmaStyleType | "STROKE",
   styleBucket: StyleBucket,
   targetNode: BaseNode
-) {
-  let styleId: string | symbol = "";
-  // check corresponding Id props to verify exact matches
-  if (styleType === "FILL") {
-    styleId = (targetNode as RectangleNode).fillStyleId;
-  }
+): FigmaTeamStyle | undefined {
+  let styleId: string | string[] | symbol | undefined;
 
-  if (styleType === "STROKE") {
-    styleId = (targetNode as RectangleNode).strokeStyleId;
-    // Figma doesn't differentiate stroke as a Fill Style
-    styleType = "FILL";
-  }
+  // Determine the styleId based on the styleType
+  switch (styleType) {
+    case "FILL":
+      styleId = (targetNode as RectangleNode).fillStyleId;
+      break;
 
-  if (styleType === "TEXT") {
-    styleId = (targetNode as TextNode).textStyleId;
+    case "STROKE":
+      styleId = (targetNode as RectangleNode).strokeStyleId;
+      styleType = "FILL"; // Figma styles don't differentiate STROKE as a style_type
+      break;
+
+    case "TEXT":
+      styleId = (targetNode as TextNode)
+        .getStyledTextSegments(["textStyleId"])
+        .map((segment) => segment.textStyleId);
+      break;
   }
 
   const styles = styleBucket[styleType];
 
-  // check if the style exists in our map, else check property by property
+  // Check if the style(s) exist in our map
   if (styleId && styleId !== figma.mixed) {
-    if (typeof styleId === "string") {
-      // get the key from the style node ID
-      const styleNodeId = styleId.split(":")[1]?.split(",")[0];
+    // Extract the key from the style node ID
+    const getStyleKey = (id: string) => id.split(":")[1]?.split(",")[0];
 
-      const existingStyle = styles[styleNodeId];
-      if (existingStyle) {
-        return existingStyle;
+    // Single style ID
+    if (typeof styleId === "string") {
+      const styleKey = getStyleKey(styleId);
+      return styles[styleKey];
+    }
+
+    // Multiple style IDs are possible for text node character ranges
+    else if (Array.isArray(styleId)) {
+      // Make sure all ids match an existing style
+      const allStylesExist = styleId.every((id) => {
+        const styleKey = getStyleKey(id);
+        return styleKey !== "" && styles[styleKey];
+      });
+
+      if (allStylesExist) {
+        // :TODO: Not sure if the returned style key is being used by callers,
+        // and if we should possibly return the full style array here
+        // maybe we should really be returning a boolean from this function
+        return styles[getStyleKey(styleId[0])];
       }
     }
   }
@@ -56,37 +79,44 @@ function isExactStyleMatchFromCloud(
   styleType: FigmaStyleType | "STROKE",
   styleBucket: StyleBucket,
   targetNode: BaseNode
-) {
+): FigmaTeamStyle | undefined {
   if (!(targetNode as any).styles) {
-    return false;
+    return undefined;
   }
 
-  let styleKey: string | symbol = "";
-  // check corresponding Id props to verify exact matches
-  if (styleType === "FILL") {
-    styleKey = (targetNode as any).styles["fill"];
+  let styleKey: string | undefined;
+
+  // Determine the styleId based on the styleType
+  switch (styleType) {
+    case "FILL":
+      styleKey = (targetNode as any).styles["fill"];
+      break;
+
+    case "STROKE":
+      // Figma styles don't differentiate STROKE as a style_type
+      styleType = "FILL";
+      styleKey = (targetNode as any).styles["stroke"];
+      break;
+
+    case "TEXT":
+      /**
+       * Note: The REST API doesn't provide the level of detail we need to detect multiple range library style ids in a text node.
+       *
+       * In node.styles["text"] we only get the first style id that is used.
+       *
+       * We can additionally ask for "characterStyleOverrides" and a "styleOverrideTable" to map those character positions,
+       * ...but it just includes the actual text properties (font family, fontSize, etc) and no indication of an associated shared Style ID.
+       * ref: https://www.figma.com/developers/api#node-types
+       *
+       * It is a known issue and has an open request:
+       * https://forum.figma.com/t/bug-text-style-overrides-inherited-from-shared-styles-are-impossible-to-read/77947
+       *
+       * The result here is that we can only detect the first style id used in the text node, and if that is an exact match
+       * to a library style then we might be reporting a false positive if there is other non-style text used in the node.
+       */
+      styleKey = (targetNode as any).styles["text"];
+      break;
   }
 
-  // may be error prone because fill style could correspond to fill rather than stroke
-  if (styleType === "STROKE") {
-    styleKey = (targetNode as any).styles["stroke"];
-
-    // some hacky stuff because Figma doesn't differentiate stroke as a Fill Style
-    styleType = "FILL";
-  }
-
-  if (styleType === "TEXT") {
-    styleKey = (targetNode as any).styles["text"];
-  }
-
-  // if a predefined style exists it's an exact match
-  if (styleKey) {
-    if (typeof styleKey === "string") {
-      if (styleBucket[styleType][styleKey]) {
-        return styleBucket[styleType][styleKey];
-      }
-    }
-  }
-
-  return undefined;
+  return styleKey ? styleBucket[styleType]?.[styleKey] : undefined;
 }


### PR DESCRIPTION
## Original report
> Currently, multiple Text Styles in the same text field are marked as not compliance, even if both styles are compliant. 

## Solution
Previously we were skipping `TEXT` nodes with `figma.mixed` styles, meaning there are multiple character ranges using different text properties. This PR adds a new check to `rules/utils/styles/exact.ts`:
* If a `TEXT` node has multiple character ranges, and they're all using matching styles, that should count as a _Exact_ match.

## Details
### Plugin API
In the Plugin API we have access to any styles ids used for each character range via [`getStyledTextSegments()`](https://www.figma.com/plugin-docs/api/properties/TextNode-getstyledtextsegments/):
```js
textNode.getStyledTextSegments(["textStyleId"])
```

### REST API
The REST API, however, _doesn't_ provide the level of detail we need to detect multiple range library style ids in a `TEXT` node.

In `node.styles["text"]` we only get the first style id used, if any.

We could additionally grab the node's `characterStyleOverrides` and the `styleOverrideTable` to map those character positions, but that only includes the actual individual text properties (`fontFamily`, `fontSize`, etc) and no indication of an associated shared Style ID being used.
_ref: https://www.figma.com/developers/api#node-types_

It is a known issue and has an open request:
https://forum.figma.com/t/bug-text-style-overrides-inherited-from-shared-styles-are-impossible-to-read/77947

The impact here is that we can only detect the first style id used in the `TEXT` node from the REST API, and if that is a match to a library style then we might be reporting a false positive _Exact_ match even if there is other non-style text used in the node.

## Additional Notes
Possible Plugin/REST API difference workaround for future implementation... we _could_ feed all the various text properties for each character range from the REST API back through our `getLintResults()` function to map them to known text styles and see if all characters in a `TEXT` node using them... and thus be an _Exact_ match result.