### PR TITLE
Manually generate resolved variable modes from the node hierarchy explicitVariableModes values

### DIFF
--- a/src/utils/variables.ts
+++ b/src/utils/variables.ts
@@ -1,19 +1,23 @@
 import { FigmaLocalVariableCollections, FigmaLocalVariables } from "../models/figma";
 
+export type FigmaVariableMapVariable = {
+  name: string;
+  description: string;
+  variableId: string;
+  variableKey: string;
+  variableCollectionId: string;
+  variableCollectionKey: string;
+  variableCollectionName: string;
+  variableCollectionDefaultModeId: string;
+  modeId: string;
+  modeName: string;
+  scopes: VariableScope[];
+};
+
 export type HexColorToFigmaVariableMap = Record<
   string,
-  Array<{
-    name: string;
-    description: string;
-    variableId: string;
-    variableKey: string;
-    variableCollectionId: string;
-    variableCollectionKey: string;
-    variableCollectionName: string;
-    modeId: string;
-    modeName: string;
-    scopes: VariableScope[];
-  }>
+  FigmaVariableMapVariable[]
+>;
 >;
 
 // Allow strictNullChecks to properly detect null filtering using a filter()
@@ -139,6 +143,7 @@ export const createHexColorToVariableMap = (
         variableCollectionId,
         variableCollectionKey: variableCollections[variableCollectionId].key,
         variableCollectionName: variableCollections[variableCollectionId].name,
+        variableCollectionDefaultModeId: variableCollections[variableCollectionId].defaultModeId,
         modeId,
         modeName: variableModeNameMap[modeId],
         scopes: variables[variableId].scopes,


### PR DESCRIPTION
## Summary
The `getVariableLookupMatches()` method was using a property available from the Plugin API called [`resolvedVariableModes`](https://www.figma.com/plugin-docs/api/properties/nodes-resolvedvariablemodes/) to properly suggest variables that matched the current resolved variable collection mode for the given node.

Sometime in early October 2024 this property appears to now only be populated by the Plugin API for variable collections that are actually currently in use by the node (i.e. It now returns an empty object for a node without any variable usage.)

## Impact
The effect of this is that the `getVariableLookupMatches` suggestions no longer have the context required to properly select only the variables that match the current property value a node (ex: a fill color hex value)

So for example... a #000 rectangle whose parent is set to a variable collection's default "light" mode might now end up matching a variable's dark mode value because its value is #000... but in light mode the variable's color is #FFF... applying that suggested variable would change the color of the rectangle and visually break the design.

## Resolution
Note: The Figma REST API never had `resolvedVariableModes`, so this library previously only supported variable mode filtered matches when used with the Plugin API.

Both the Plugin API and REST API have the [`explicitVariableModes`](https://www.figma.com/plugin-docs/api/node-properties/#explicitvariablemodes) property, and from that we can walk up the node hierarchy and manually generate what we previously had available in the `resolvedVariableModes` property.

Additionally, if a resolved variable collection mode can't be determined for the node, we now fall back to using the collection's `defaultModeId`.