### PR TITLE
GESTALT-7527: Radius Token Matching

### DIFF
--- a/src/models/stats.ts
+++ b/src/models/stats.ts
@@ -45,12 +45,19 @@ export type AdoptionCalculationOptions = {
   includePartialFills?: boolean;
 };
 
+export type RadiusVariable =
+  | "bottomLeftRadius"
+  | "bottomRightRadius"
+  | "topLeftRadius"
+  | "topRightRadius";
+
 export type LintCheckName =
-  | "Text-Style"
   | "Fill-Style"
-  | "Stroke-Fill-Style"
   | "Fill-Variable"
-  | "Stroke-Fill-Variable";
+  | "Rounding-Variable"
+  | "Stroke-Fill-Style"
+  | "Stroke-Fill-Variable"
+  | "Text-Style";
 
 export type MatchLevel = "None" | "Partial" | "Full" | "Skip";
 
@@ -58,16 +65,16 @@ type LintSuggestionBase = {
   message: string;
   name: string;
   description?: string;
-  hexColor?: string;
 };
 
 export type LintSuggestionStyle = LintSuggestionBase & {
-  type: "Style"
+  type: "Style";
   styleKey: string;
 };
 
 export type LintSuggestionVariable = LintSuggestionBase & {
   type: "Variable";
+  hexColor?: string;
   variableId: string;
   variableKey: string;
   variableCollectionId: string;
@@ -76,7 +83,7 @@ export type LintSuggestionVariable = LintSuggestionBase & {
   modeId: string;
   modeName: string;
   scopes: VariableScope[];
-}
+};
 
 export type LintSuggestion = LintSuggestionStyle | LintSuggestionVariable;
 
@@ -104,7 +111,7 @@ export type LintCheckPercent = {
 };
 
 export type AggregateCountsCompliance = {
-  [key in "fills" | "strokes" | "text"]: {
+  [key in "fills" | "rounding" | "strokes" | "text"]: {
     attached: number;
     detached: number;
     none: number;

--- a/src/rules/fillStyle.ts
+++ b/src/rules/fillStyle.ts
@@ -1,7 +1,7 @@
 import jp from "jsonpath";
 
 import { StyleBucket } from "../models/figma";
-import { LintCheck, LintSuggestion } from "../models/stats";
+import { LintCheck, LintCheckName, LintSuggestion } from "../models/stats";
 
 import {
   getStyleLookupDefinitions,
@@ -18,7 +18,7 @@ export default function checkFillStyleMatch(
   targetNode: BaseNode,
   opts?: LintCheckOptions
 ): LintCheck {
-  const checkName = "Fill-Style";
+  const checkName: LintCheckName = "Fill-Style";
 
   // check if correct Node Type
   // REST API uses "REGULAR_POLYGON" but Figma uses "POLYGON"
@@ -37,7 +37,6 @@ export default function checkFillStyleMatch(
   );
   if (colorVariables.length > 0)
     return { checkName, matchLevel: "Skip", suggestions: [] };
-
 
   if (!hasValidFillToMatch(targetNode as MinimalFillsMixin))
     return { checkName, matchLevel: "Skip", suggestions: [] };
@@ -82,7 +81,7 @@ export default function checkFillStyleMatch(
             message: `Color Override Exists in Library for hex ${hex}`,
             styleKey,
             name: hex,
-            description: "Direct hex color mapping override"
+            description: "Direct hex color mapping override",
           });
         }
         return { matchLevel: "Partial", checkName, suggestions };

--- a/src/rules/fillVariable.ts
+++ b/src/rules/fillVariable.ts
@@ -1,7 +1,11 @@
 import { FigmaLocalVariables } from "../models/figma";
-import { LintCheck } from "../models/stats";
+import { LintCheck, LintCheckName } from "../models/stats";
 
-import { LintCheckOptions, hasValidFillToMatch, isNodeOfTypeAndVisible } from ".";
+import {
+  LintCheckOptions,
+  hasValidFillToMatch,
+  isNodeOfTypeAndVisible,
+} from ".";
 import { isExactVariableMatch } from "./utils/variables/exact";
 import getVariableLookupMatches from "./utils/variables/lookup";
 
@@ -10,7 +14,7 @@ export default function checkFillVariableMatch(
   targetNode: BaseNode,
   opts?: LintCheckOptions
 ): LintCheck {
-  const checkName = "Fill-Variable";
+  const checkName: LintCheckName = "Fill-Variable";
 
   // Check if correct Node Type
   // REST API uses "REGULAR_POLYGON" but Figma uses "POLYGON"

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -15,9 +15,13 @@ import jp from "jsonpath";
 import checkFillStyleMatch from "./fillStyle";
 import checkStrokeStyleMatch from "./strokeStyle";
 import checkTextMatch from "./textStyle";
-import { HexColorToFigmaVariableMap } from "../utils/variables";
+import {
+  HexColorToFigmaVariableMap,
+  RoundingToFigmaVariableMap,
+} from "../utils/variables";
 import checkFillVariableMatch from "./fillVariable";
 import checkStrokeVariableMatch from "./strokeVariable";
+import checkRoundingVariableMatch from "./roundingVariable";
 
 /**
  * styleLookupMap - required for partial matches
@@ -26,6 +30,7 @@ export type LintCheckOptions = {
   hexStyleMap?: HexStyleMap;
   styleLookupMap?: StyleLookupMap;
   hexColorToVariableMap?: HexColorToFigmaVariableMap;
+  roundingToVariableMap?: RoundingToFigmaVariableMap;
 };
 /**
  * Run through all partial matches, and make exceptions depending on rules
@@ -50,7 +55,11 @@ export const runSimilarityChecks = (
     variables: FigmaLocalVariables,
     targetNode: BaseNode,
     opts?: LintCheckOptions
-  ) => LintCheck)[] = [checkFillVariableMatch, checkStrokeVariableMatch];
+  ) => LintCheck)[] = [
+    checkFillVariableMatch,
+    checkStrokeVariableMatch,
+    checkRoundingVariableMatch,
+  ];
 
   const results = [];
 
@@ -88,6 +97,15 @@ export const hasValidFillToMatch = (node: MinimalFillsMixin) => {
     fills.length > 0 && // Has at least one fill
     !fills.some((f) => f.visible === false) && // No hidden fills
     !fills.some((f) => f.type === "IMAGE") // No image fills
+  );
+};
+
+export const hasValidRoundingToMatch = (node: CornerMixin) => {
+  const { cornerRadius } = node;
+
+  return (
+    cornerRadius !== undefined && // Must have a cornerRadius property
+    cornerRadius !== 0 // Skip default 0 value corner radius nodes
   );
 };
 

--- a/src/rules/roundingVariable.ts
+++ b/src/rules/roundingVariable.ts
@@ -17,9 +17,10 @@ export default function checkRoundingVariableMatch(
   const checkName: LintCheckName = "Rounding-Variable";
 
   // Check if correct Node Type
+  // REST API uses "REGULAR_POLYGON" but Figma uses "POLYGON"
   if (
     !isNodeOfTypeAndVisible(
-      ["ELLIPSE", "INSTANCE", "POLYGON", "RECTANGLE", "STAR", "VECTOR"],
+      ["INSTANCE", "POLYGON", "REGULAR_POLYGON", "RECTANGLE", "STAR", "VECTOR"],
       targetNode
     )
   )

--- a/src/rules/roundingVariable.ts
+++ b/src/rules/roundingVariable.ts
@@ -3,41 +3,33 @@ import { LintCheck, LintCheckName } from "../models/stats";
 
 import {
   LintCheckOptions,
-  hasValidFillToMatch,
+  hasValidRoundingToMatch,
   isNodeOfTypeAndVisible,
 } from ".";
 import { isExactVariableMatch } from "./utils/variables/exact";
 import getVariableLookupMatches from "./utils/variables/lookup";
 
-export default function checkFillVariableMatch(
+export default function checkRoundingVariableMatch(
   variables: FigmaLocalVariables,
   targetNode: BaseNode,
   opts?: LintCheckOptions
 ): LintCheck {
-  const checkName: LintCheckName = "Fill-Variable";
+  const checkName: LintCheckName = "Rounding-Variable";
 
   // Check if correct Node Type
-  // REST API uses "REGULAR_POLYGON" but Figma uses "POLYGON"
   if (
     !isNodeOfTypeAndVisible(
-      ["ELLIPSE", "INSTANCE", "POLYGON", "REGULAR_POLYGON", "RECTANGLE", "STAR", "TEXT", "VECTOR"],
+      ["ELLIPSE", "INSTANCE", "POLYGON", "RECTANGLE", "STAR", "VECTOR"],
       targetNode
     )
   )
     return { checkName, matchLevel: "Skip", suggestions: [] };
 
-  // Don't do variable processing if a fill style is in-use
-  if (
-    (targetNode as MinimalFillsMixin).fillStyleId ||
-    (targetNode as any).styles?.fill
-  )
-    return { checkName, matchLevel: "Skip", suggestions: [] };
-
-  if (!hasValidFillToMatch(targetNode as MinimalFillsMixin))
+  if (!hasValidRoundingToMatch(targetNode as CornerMixin))
     return { checkName, matchLevel: "Skip", suggestions: [] };
 
   // check if variable is exact match
-  const exactMatch = isExactVariableMatch("FILL", variables, targetNode);
+  const exactMatch = isExactVariableMatch("ROUNDING", variables, targetNode);
 
   if (exactMatch)
     return {
@@ -48,12 +40,12 @@ export default function checkFillVariableMatch(
     };
 
   // Variable matching
-  if (opts?.hexColorToVariableMap) {
+  if (opts?.roundingToVariableMap) {
     const { matchLevel, suggestions } = getVariableLookupMatches(
       checkName,
-      opts.hexColorToVariableMap,
-      {}, // opts.roundingToVariableMap not used in this check
-      "FILL",
+      {}, // opts.hexColorToVariableMap not used in this check
+      opts.roundingToVariableMap,
+      "ROUNDING",
       targetNode
     );
 

--- a/src/rules/strokeStyle.ts
+++ b/src/rules/strokeStyle.ts
@@ -1,5 +1,5 @@
 import { StyleBucket } from "../models/figma";
-import { LintCheck, LintSuggestion } from "../models/stats";
+import { LintCheck, LintCheckName, LintSuggestion } from "../models/stats";
 
 import {
   getStyleLookupDefinitions,
@@ -17,7 +17,7 @@ export default function checkStrokeStyleMatch(
   targetNode: BaseNode,
   opts?: LintCheckOptions
 ): LintCheck {
-  const checkName = "Stroke-Fill-Style";
+  const checkName: LintCheckName = "Stroke-Fill-Style";
 
   // check if correct Node Type
   // REST API uses "REGULAR_POLYGON" but Figma uses "POLYGON"

--- a/src/rules/strokeVariable.ts
+++ b/src/rules/strokeVariable.ts
@@ -52,6 +52,7 @@ export default function checkStrokeVariableMatch(
     const { matchLevel, suggestions } = getVariableLookupMatches(
       checkName,
       opts.hexColorToVariableMap,
+      {}, // opts.roundingToVariableMap not used in this check
       "STROKE",
       targetNode
     );

--- a/src/rules/strokeVariable.ts
+++ b/src/rules/strokeVariable.ts
@@ -1,5 +1,5 @@
 import { FigmaLocalVariables } from "../models/figma";
-import { LintCheck } from "../models/stats";
+import { LintCheck, LintCheckName } from "../models/stats";
 
 import {
   LintCheckOptions,
@@ -14,7 +14,7 @@ export default function checkStrokeVariableMatch(
   targetNode: BaseNode,
   opts?: LintCheckOptions
 ): LintCheck {
-  const checkName = "Stroke-Fill-Variable";
+  const checkName: LintCheckName = "Stroke-Fill-Variable";
 
   // Check if correct Node Type
   // REST API uses "REGULAR_POLYGON" but Figma uses "POLYGON"

--- a/src/rules/textStyle.ts
+++ b/src/rules/textStyle.ts
@@ -1,5 +1,5 @@
 import { StyleBucket } from "../models/figma";
-import { LintCheck } from "../models/stats";
+import { LintCheck, LintCheckName } from "../models/stats";
 
 import { isNodeOfTypeAndVisible, LintCheckOptions } from ".";
 import { isExactStyleMatch } from "./utils/styles/exact";
@@ -10,7 +10,7 @@ export default function checkTextMatch(
   targetNode: BaseNode,
   opts?: LintCheckOptions
 ): LintCheck {
-  const checkName = "Text-Style";
+  const checkName: LintCheckName = "Text-Style";
   // console.log(targetNode);
   // check if correct Node Type
   if (!isNodeOfTypeAndVisible(["TEXT"], targetNode))

--- a/src/rules/utils/styles/exact.ts
+++ b/src/rules/utils/styles/exact.ts
@@ -47,7 +47,7 @@ function isExactStyleMatchInFigma(
   // Check if the style(s) exist in our map
   if (styleId && styleId !== figma.mixed) {
     // Extract the key from the style node ID
-    const getStyleKey = (id: string) => id.split(":")[1]?.split(",")[0];
+    const getStyleKey = (id: string) => id?.split(":")[1]?.split(",")[0];
 
     // Single style ID
     if (typeof styleId === "string") {

--- a/src/rules/utils/styles/lookup.ts
+++ b/src/rules/utils/styles/lookup.ts
@@ -2,7 +2,7 @@ import jp from "jsonpath";
 
 import { getStyleLookupDefinitions, getStyleLookupKey } from "../..";
 import { FigmaStyleType, StyleLookupMap } from "../../../models/figma";
-import { LintCheckName, LintCheck, LintSuggestion } from "../../../models/stats";
+import { LintCheckName, LintCheck, LintSuggestionStyle } from "../../../models/stats";
 
 /**
  * Check if any sub properties overlap and match
@@ -18,7 +18,7 @@ export default function getStyleLookupMatches(
   styleType: FigmaStyleType | "STROKE",
   targetNode: BaseNode
 ): LintCheck {
-  const suggestions: LintSuggestion[] = [];
+  const suggestions: LintSuggestionStyle[] = [];
 
   const propsToCheck = getStyleLookupDefinitions(styleType);
 

--- a/src/rules/utils/variables/exact.ts
+++ b/src/rules/utils/variables/exact.ts
@@ -72,9 +72,20 @@ export const isExactVariableMatch = (
 
     case "ROUNDING":
       {
-        const matchingVariables: FigmaLocalVariable[] = [];
+        // Non-Rectangle nodes (e.g. Polygon, Star) can have a single cornerRadius bound variable
+        // NOTE: boundVariables.cornerRadius isn't documented or in the Figma typings currently, so using any
+        const variableSubscribedId = (targetNode as any).boundVariables
+          ?.cornerRadius?.id;
 
-        // Check all the corner radius bound variables, if they exist
+        if (variableSubscribedId) {
+          const variable = getVariableFromSubscribedId(variableSubscribedId);
+          if (variable && variable.scopes.includes("CORNER_RADIUS")) {
+            return variable;
+          }
+        }
+
+        // Otherwise, check all the corner radius bound variables, if they exist
+        const matchingVariables: FigmaLocalVariable[] = [];
         (
           [
             "bottomLeftRadius",

--- a/src/rules/utils/variables/exact.ts
+++ b/src/rules/utils/variables/exact.ts
@@ -108,11 +108,8 @@ export const isExactVariableMatch = (
 
         // If they all match, return the first one
         // :TODO: Do callers use this returned variable key?
-        return matchingVariables.length === 4
-          ? matchingVariables[0]
-          : undefined;
+        if (matchingVariables.length === 4) return matchingVariables[0];
       }
-
       break;
 
     default: {

--- a/src/rules/utils/variables/exact.ts
+++ b/src/rules/utils/variables/exact.ts
@@ -1,7 +1,8 @@
 import { FigmaLocalVariable, FigmaLocalVariables } from "../../../models/figma";
+import { RadiusVariable } from "../../../models/stats";
 
 export const isExactVariableMatch = (
-  variableType: "FILL" | "STROKE",
+  variableType: "FILL" | "ROUNDING" | "STROKE",
   variables: FigmaLocalVariables,
   targetNode: BaseNode
 ): FigmaLocalVariable | undefined => {
@@ -9,50 +10,104 @@ export const isExactVariableMatch = (
   // VariableID:2eba2a28539ae56f55778b021a50ecafea5bb4eb/6719:357
   function getVariableFromSubscribedId(subscribedId: string) {
     const match = subscribedId.match(/VariableID:(\w+)\//);
-    const variableKey = match ? match[1] : null;
+    const variableKey = match?.[1] ?? undefined;
 
-    return Object.values(variables).find((variable) => variable.key === variableKey);
+    return (
+      variableKey && Object.values(variables).find((v) => v.key === variableKey)
+    );
   }
 
-  if (variableType === "FILL") {
-    // boundVariables reference the subscribed_id of the variable in the format:
-    // VariableID:2eba2a28539ae56f55778b021a50ecafea5bb4eb/6719:357
-    //
-    // From the Figma REST API docs:
-    // Published variables have two ids: an id that is assigned in the file where it is created (id),
-    // and an id that is used by subscribing files (subscribed_id). The id and key are stable over
-    // the lifetime of the variable. The subscribed_id changes every time the variable is modified
-    // and published. The same is true for variable collections.
-    //
-    const variableSubscribedId = (targetNode as RectangleNode).boundVariables?.fills?.[0].id;
+  switch (variableType) {
+    case "FILL":
+      {
+        // boundVariables reference the subscribed_id of the variable in the format:
+        // VariableID:2eba2a28539ae56f55778b021a50ecafea5bb4eb/6719:357
+        //
+        // From the Figma REST API docs:
+        // Published variables have two ids: an id that is assigned in the file where it is created (id),
+        // and an id that is used by subscribing files (subscribed_id). The id and key are stable over
+        // the lifetime of the variable. The subscribed_id changes every time the variable is modified
+        // and published. The same is true for variable collections.
+        //
+        const variableSubscribedId = (targetNode as RectangleNode)
+          .boundVariables?.fills?.[0].id;
 
-    if (variableSubscribedId) {
-      const variable = getVariableFromSubscribedId(variableSubscribedId);
+        if (variableSubscribedId) {
+          const variable = getVariableFromSubscribedId(variableSubscribedId);
 
-      // const figmaLoadedVariable = figma.variables.getVariableById(variableId);
-      // console.log("Got figma loaded variable:", figmaLoadedVariable);
+          // const figmaLoadedVariable = figma.variables.getVariableById(variableId);
+          // console.log("Got figma loaded variable:", figmaLoadedVariable);
 
-      if (
-        variable &&
-        (variable.scopes.includes("SHAPE_FILL") ||
-          variable.scopes.includes("FRAME_FILL") ||
-          variable.scopes.includes("TEXT_FILL") ||
-          variable.scopes.includes("ALL_SCOPES"))
-      ) {
-        return variable;
+          if (
+            variable &&
+            (variable.scopes.includes("SHAPE_FILL") ||
+              variable.scopes.includes("FRAME_FILL") ||
+              variable.scopes.includes("TEXT_FILL") ||
+              variable.scopes.includes("ALL_SCOPES"))
+          ) {
+            return variable;
+          }
+        }
       }
-    }
-  }
+      break;
 
-  if (variableType === "STROKE") {
-    const variableSubscribedId = (targetNode as RectangleNode).boundVariables?.strokes?.[0].id;
+    case "STROKE":
+      {
+        const variableSubscribedId = (targetNode as RectangleNode)
+          .boundVariables?.strokes?.[0].id;
 
-    if (variableSubscribedId) {
-      const variable = getVariableFromSubscribedId(variableSubscribedId);
+        if (variableSubscribedId) {
+          const variable = getVariableFromSubscribedId(variableSubscribedId);
 
-      if (variable && (variable.scopes.includes("STROKE_COLOR") || variable.scopes.includes("ALL_SCOPES"))) {
-        return variable;
+          if (
+            variable &&
+            (variable.scopes.includes("STROKE_COLOR") ||
+              variable.scopes.includes("ALL_SCOPES"))
+          ) {
+            return variable;
+          }
+        }
       }
+      break;
+
+    case "ROUNDING":
+      {
+        const matchingVariables: FigmaLocalVariable[] = [];
+
+        // Check all the corner radius bound variables, if they exist
+        (
+          [
+            "bottomLeftRadius",
+            "bottomRightRadius",
+            "topLeftRadius",
+            "topRightRadius",
+          ] as RadiusVariable[]
+        ).forEach((radius) => {
+          const variableSubscribedId = (targetNode as RectangleNode)
+            .boundVariables?.[radius]?.id;
+
+          if (variableSubscribedId) {
+            const variable = getVariableFromSubscribedId(variableSubscribedId);
+
+            if (variable && variable.scopes.includes("CORNER_RADIUS")) {
+              matchingVariables.push(variable);
+            }
+          }
+        });
+
+        // If they all match, return the first one
+        // :TODO: Do callers use this returned variable key?
+        return matchingVariables.length === 4
+          ? matchingVariables[0]
+          : undefined;
+      }
+
+      break;
+
+    default: {
+      // Make sure all variable types are handled
+      const _unreachable: never = variableType;
+      throw new Error(`Unhandled variableType: ${_unreachable}`);
     }
   }
 

--- a/src/rules/utils/variables/lookup.ts
+++ b/src/rules/utils/variables/lookup.ts
@@ -60,7 +60,10 @@ export default function getVariableLookupMatches(
 
     case "ROUNDING":
       // Only offer rounding suggestions for nodes that have a single, non-figma.mixed cornerRadius
-      // :TODO: Figure out if we want to expanded this to support figma.mixed radius values
+      // :TODO: Figure out if we want to expanded this to support figma.mixed radius values,
+      // which would mean needing to check:
+      // Plugin API: "bottomLeftRadius", "bottomRightRadius", "topLeftRadius", "topRightRadius" for the Plugin API
+      // REST API: "rectangleCornerRadii" array
       const cornerRadius = (targetNode as CornerMixin).cornerRadius;
       if (typeof cornerRadius === "number") {
         variables = roundingToVariableMap[cornerRadius];

--- a/src/rules/utils/variables/lookup.ts
+++ b/src/rules/utils/variables/lookup.ts
@@ -4,45 +4,75 @@ import {
   LintSuggestionVariable,
 } from "../../../models/stats";
 import {
+  FigmaVariableMapVariable,
   HexColorToFigmaVariableMap,
   rgbaToHex,
+  RoundingToFigmaVariableMap,
 } from "../../../utils/variables";
 
 export default function getVariableLookupMatches(
   checkName: LintCheckName,
   hexColorToVariableMap: HexColorToFigmaVariableMap,
-  variableType: "FILL" | "STROKE",
+  roundingToVariableMap: RoundingToFigmaVariableMap,
+  variableType: "FILL" | "ROUNDING" | "STROKE",
   targetNode: BaseNode
 ): LintCheck {
-  let paints: readonly Paint[] | typeof figma.mixed | undefined;
   const suggestions: LintSuggestionVariable[] = [];
+  let variables: FigmaVariableMapVariable[] | undefined;
+  let hexColor: string | undefined;
 
-  if (variableType === "FILL") paints = (targetNode as MinimalFillsMixin).fills;
-  else if (variableType === "STROKE")
-    paints = (targetNode as MinimalStrokesMixin).strokes;
+  switch (variableType) {
+    case "FILL":
+    case "STROKE":
+      {
+        let paints: readonly Paint[] | typeof figma.mixed | undefined;
 
-  // Paints in the Figma plugin could be figma.mixed, but in the Figma Cloud file figma.mixed
-  // isn't available.. so use isArray to make sure it isn't figma.mixed (which is a unique symbol type)
-  if (
-    paints &&
-    Array.isArray(paints) &&
-    paints.length > 0 &&
-    paints[0].type === "SOLID"
-  ) {
-    const paint = paints[0];
+        if (variableType === "FILL")
+          paints = (targetNode as MinimalFillsMixin).fills;
+        else if (variableType === "STROKE")
+          paints = (targetNode as MinimalStrokesMixin).strokes;
 
-    if (paint.visible === false) {
-      return { checkName, matchLevel: "Skip", suggestions: [] };
+        // Paints in the Figma plugin could be figma.mixed, but in the Figma Cloud file figma.mixed
+        // isn't available.. so use isArray to make sure it isn't figma.mixed (which is a unique symbol type)
+        if (
+          paints &&
+          Array.isArray(paints) &&
+          paints.length > 0 &&
+          paints[0].type === "SOLID"
+        ) {
+          const paint = paints[0];
+
+          if (paint.visible === false) {
+            return { checkName, matchLevel: "Skip", suggestions: [] };
+          }
+
+          // Figma plugin nodes use RBA + opacity, Figma Cloud file nodes use RGBA
+          const rgba = {
+            ...paint.color,
+            a: ((paint.color as RGBA).a || paint.opacity) ?? 1,
+          };
+
+          hexColor = rgbaToHex(rgba);
+          variables = hexColorToVariableMap[hexColor];
+        }
+      }
+      break;
+
+    case "ROUNDING":
+      // Only offer rounding suggestions for nodes that have a single, non-figma.mixed cornerRadius
+      // :TODO: Figure out if we want to expanded this to support figma.mixed radius values
+      const cornerRadius = (targetNode as CornerMixin).cornerRadius;
+      if (typeof cornerRadius === "number") {
+        variables = roundingToVariableMap[cornerRadius];
+      }
+      break;
+
+    default: {
+      // Make sure all variable types are handled
+      const _unreachable: never = variableType;
+      throw new Error(`Unhandled variableType: ${_unreachable}`);
     }
-
-    // Figma plugin nodes use RBA + opacity, Figma Cloud file nodes use RGBA
-    const rgba = {
-      ...paint.color,
-      a: ((paint.color as RGBA).a || paint.opacity) ?? 1,
-    };
-
-    const hexColor = rgbaToHex(rgba);
-    let variables = hexColorToVariableMap[hexColor];
+  }
 
   if (variables) {
     // Filter out variables that don't match the resolvedVariableModes for the node
@@ -67,7 +97,7 @@ export default function getVariableLookupMatches(
     // lookup map for faster filtering
     let currentNode = targetNode as SceneNode | BaseNode | null;
     while (currentNode && currentNode.type !== "DOCUMENT") {
-      const modes = currentNode.explicitVariableModes;
+      const modes = currentNode.explicitVariableModes ?? {};
 
       for (const [key, value] of Object.entries(modes)) {
         const collectionKey = key.match(/:(.+)\//)?.[1];
@@ -91,23 +121,26 @@ export default function getVariableLookupMatches(
       return v.modeId === modeToMatch;
     });
 
-      for (const v of variables) {
-        suggestions.push({
-          type: "Variable",
-          message: `Possible Gestalt ${checkName} match with name: ${v.name}`,
-          name: v.name,
-          hexColor,
-          description: v.description,
-          variableId: v.variableId,
-          variableKey: v.variableKey,
-          variableCollectionId: v.variableCollectionId,
-          variableCollectionKey: v.variableCollectionKey,
-          variableCollectionName: v.variableCollectionName,
-          modeId: v.modeId,
-          modeName: v.modeName,
-          scopes: v.scopes,
-        });
-      }
+    for (const v of variables) {
+      const suggestion: LintSuggestionVariable = {
+        type: "Variable",
+        message: `Possible Gestalt ${checkName} match with name: ${v.name}`,
+        name: v.name,
+        description: v.description,
+        variableId: v.variableId,
+        variableKey: v.variableKey,
+        variableCollectionId: v.variableCollectionId,
+        variableCollectionKey: v.variableCollectionKey,
+        variableCollectionName: v.variableCollectionName,
+        modeId: v.modeId,
+        modeName: v.modeName,
+        scopes: v.scopes,
+      };
+
+      // Only used for FILL and STROKE suggestions
+      if (hexColor) suggestion.hexColor = hexColor;
+
+      suggestions.push(suggestion);
     }
   }
 

--- a/src/rules/utils/variables/lookup.ts
+++ b/src/rules/utils/variables/lookup.ts
@@ -1,7 +1,7 @@
 import {
   LintCheckName,
   LintCheck,
-  LintSuggestion,
+  LintSuggestionVariable,
 } from "../../../models/stats";
 import {
   HexColorToFigmaVariableMap,
@@ -14,8 +14,8 @@ export default function getVariableLookupMatches(
   variableType: "FILL" | "STROKE",
   targetNode: BaseNode
 ): LintCheck {
-  const suggestions: LintSuggestion[] = [];
   let paints: readonly Paint[] | typeof figma.mixed | undefined;
+  const suggestions: LintSuggestionVariable[] = [];
 
   if (variableType === "FILL") paints = (targetNode as MinimalFillsMixin).fills;
   else if (variableType === "STROKE")

--- a/src/utils/process.ts
+++ b/src/utils/process.ts
@@ -5,12 +5,7 @@ import {
   FigmaTeamComponent,
   FigmaTeamStyle,
 } from "../models/figma";
-import {
-  AdoptionCalculationOptions,
-  AggregateCounts,
-  LintCheckName,
-  ProcessedNode,
-} from "../models/stats";
+import { AggregateCounts, LintCheckName, ProcessedNode } from "../models/stats";
 import FigmaDocumentParser from "../parser";
 import {
   generateStyleBucket,
@@ -21,7 +16,9 @@ import {
 import { makePercent } from "./percent";
 import {
   HexColorToFigmaVariableMap,
+  RoundingToFigmaVariableMap,
   createHexColorToVariableMap,
+  createRoundingToVariableMap,
   getCollectionVariables,
 } from "./variables";
 
@@ -45,6 +42,7 @@ export function getProcessedNodes(
   components: FigmaTeamComponent[],
   allStyles: FigmaTeamStyle[],
   colorVariableCollectionIds: string[],
+  roundingVariableCollectionIds: string[],
   variables: FigmaLocalVariables,
   variableCollections: FigmaLocalVariableCollections,
   opts?: ProcessedNodeOptions
@@ -52,7 +50,7 @@ export function getProcessedNodes(
   const styleBuckets = generateStyleBucket(allStyles);
   const styleLookupMap = generateStyleLookup(styleBuckets);
 
-  // Just grab the variables from specific color variable collection(s)
+  // Grab the variables from specific color variable collection(s)
   let colorVariableIds: string[] = [];
   let hexColorToVariableMap: HexColorToFigmaVariableMap = {};
   if (
@@ -68,6 +66,27 @@ export function getProcessedNodes(
     );
     hexColorToVariableMap = createHexColorToVariableMap(
       colorVariableIds,
+      variables,
+      variableCollections
+    );
+  }
+
+  // Grab the variables from specific rounding variable collection(s)
+  let roundingVariableIds: string[] = [];
+  let roundingToVariableMap: RoundingToFigmaVariableMap = {};
+  if (
+    roundingVariableCollectionIds.length > 0 &&
+    variables &&
+    Object.keys(variables).length > 0 &&
+    variableCollections &&
+    Object.keys(variableCollections).length > 0
+  ) {
+    roundingVariableIds = getCollectionVariables(
+      roundingVariableCollectionIds,
+      variableCollections
+    );
+    roundingToVariableMap = createRoundingToVariableMap(
+      roundingVariableIds,
       variables,
       variableCollections
     );
@@ -130,6 +149,7 @@ export function getProcessedNodes(
       ...opts,
       styleLookupMap,
       hexColorToVariableMap,
+      roundingToVariableMap,
     });
 
     addToProcessedNodes({

--- a/src/utils/variables.ts
+++ b/src/utils/variables.ts
@@ -18,6 +18,10 @@ export type HexColorToFigmaVariableMap = Record<
   string,
   FigmaVariableMapVariable[]
 >;
+
+export type RoundingToFigmaVariableMap = Record<
+  number,
+  FigmaVariableMapVariable[]
 >;
 
 // Allow strictNullChecks to properly detect null filtering using a filter()
@@ -62,6 +66,8 @@ export const getCollectionVariables = (
     })
     .flat();
 };
+
+// #region Color Variables
 
 // Take a variable key and mode id and return the hex color value, recursively resolving any variable aliases
 const resolveHexValue = (variableId: string, modeId: string, variables: FigmaLocalVariables): string | null => {
@@ -153,3 +159,103 @@ export const createHexColorToVariableMap = (
     return acc;
   }, {});
 };
+// #endregion Color Variables
+
+// #region: Rounding Variables
+
+// Take a variable key and mode id and return the numeric value, recursively resolving any variable aliases
+const resolveVariableValue = (variableId: string, modeId: string, variables: FigmaLocalVariables): number | null => {
+  const variable = variables[variableId];
+  if (!variable) {
+    console.log("WARNING: No value found for the matching mode:", variableId, modeId);
+    return null;
+  }
+
+  let variableValue: VariableValue | undefined = variable.valuesByMode[modeId];
+
+  // Fallback to the first mode value for the case where the referenced mode is not found
+  if (variableValue === undefined) variableValue = Object.values(variable.valuesByMode)[0];
+
+  if (variableValue === undefined) {
+    console.log("ERROR: Unable to find a value for any mode:", variableId);
+    return null;
+  }
+
+  // Recursively resolve the value if it's a reference to another variable
+  if (isVariableAlias(variableValue)) return resolveVariableValue(variableValue.id, modeId, variables);
+
+  // check if the value is a number
+  if (typeof variableValue === "number") return variableValue;
+
+  console.log("ERROR: The variable's value is not a VariableAlias or number");
+  return null;
+};
+
+// Get the rounding/radius values for all of a variable's modes
+// ex: { variableId: "123", modeId: "456", value: 16 }
+const getModeRoundingValues = (
+  variableId: string,
+  variables: FigmaLocalVariables,
+): Array<{
+  variableId: string;
+  modeId: string;
+  value: number | null;
+}> | null => {
+  const variable = variables[variableId];
+
+  // Only include "FLOAT" type variables that are not hidden from publishing and are not remote
+  if (!variable || variable.resolvedType !== "FLOAT" || variable.hiddenFromPublishing || variable.remote) return null;
+
+  return Object.keys(variable.valuesByMode).map((modeId) => {
+    const value = resolveVariableValue(variableId, modeId, variables);
+    return { variableId, modeId, value };
+  });
+};
+
+// Group rounding variables by their radius
+export const createRoundingToVariableMap = (
+  roundingVariableIds: string[],
+  variables: FigmaLocalVariables,
+  variableCollections: FigmaLocalVariableCollections,
+): RoundingToFigmaVariableMap => {
+  const variableRoundingValues = roundingVariableIds
+    .map((variableId) => getModeRoundingValues(variableId, variables))
+    .filter(nonNullable)
+    .flat();
+
+  console.log("variableRoundingValues", variableRoundingValues);
+
+  // Create a lookup map of mode ids to their names
+  const variableModeNameMap = Object.values(variableCollections).reduce<Record<string, string>>((acc, { modes }) => {
+    modes.forEach(({ modeId, name }) => {
+      acc[modeId] = name;
+    });
+    return acc;
+  }, {});
+
+  console.log("variableModeNameMap", variableModeNameMap);
+
+  return variableRoundingValues.reduce<RoundingToFigmaVariableMap>((acc, { value, variableId, modeId }) => {
+    if (value !== null) {
+      if (!acc[value]) acc[value] = [];
+
+      const { name, description, key, variableCollectionId } = variables[variableId];
+      acc[value].push({
+        name,
+        description,
+        variableId,
+        variableKey: key,
+        variableCollectionId,
+        variableCollectionKey: variableCollections[variableCollectionId].key,
+        variableCollectionName: variableCollections[variableCollectionId].name,
+        variableCollectionDefaultModeId: variableCollections[variableCollectionId].defaultModeId,
+        modeId,
+        modeName: variableModeNameMap[modeId],
+        scopes: variables[variableId].scopes,
+      });
+    }
+
+    return acc;
+  }, {});
+};
+// #endregion: Rounding Variables

--- a/src/utils/variables.ts
+++ b/src/utils/variables.ts
@@ -223,8 +223,6 @@ export const createRoundingToVariableMap = (
     .filter(nonNullable)
     .flat();
 
-  console.log("variableRoundingValues", variableRoundingValues);
-
   // Create a lookup map of mode ids to their names
   const variableModeNameMap = Object.values(variableCollections).reduce<Record<string, string>>((acc, { modes }) => {
     modes.forEach(({ modeId, name }) => {
@@ -232,8 +230,6 @@ export const createRoundingToVariableMap = (
     });
     return acc;
   }, {});
-
-  console.log("variableModeNameMap", variableModeNameMap);
 
   return variableRoundingValues.reduce<RoundingToFigmaVariableMap>((acc, { value, variableId, modeId }) => {
     if (value !== null) {


### PR DESCRIPTION
## Summary
Adds support for matching and linting corner radius variables

## Details
* **Partial matching**
  This currently only supports corner radius linting suggestions for a single, non-`figma.mixed` `cornerRadius` value. The suggestion engine doesn't yet support returning multiple values.
* **Exact matching**
  For adoption measurements, all four corners _are_ individually and separately matched to confirm an `Exact` variable match.