### PR TITLE
GESTALT-8542:: Support for ignoring a given set of component keys

### DIFF
--- a/src/models/stats.ts
+++ b/src/models/stats.ts
@@ -121,6 +121,7 @@ export type AggregateCountsCompliance = {
 export type AggregateCounts = {
   totalNodes: number;
   hiddenNodes: number;
+  ignoredNodes: number;
   libraryNodes: number;
   checks: {
     [checkName in LintCheckName]?: {


### PR DESCRIPTION
A generalized mechanism to ignore a set of component keys to allow filtering out of things like a design Handoff Kit that shouldn't be included in linting results, or adoption measurements.

