### PR TITLE
GESTALT-7528: Spacing Token Matching

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,6 +8,8 @@ end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
+max_line_length = 120
 
 [*.md]
+max_line_length = 0
 trim_trailing_whitespace = false

--- a/src/models/stats.ts
+++ b/src/models/stats.ts
@@ -51,10 +51,19 @@ export type RadiusVariable =
   | "topLeftRadius"
   | "topRightRadius";
 
+export type SpacingVariable =
+  | "counterAxisSpacing"
+  | "itemSpacing"
+  | "paddingBottom"
+  | "paddingLeft"
+  | "paddingRight"
+  | "paddingTop";
+
 export type LintCheckName =
   | "Fill-Style"
   | "Fill-Variable"
   | "Rounding-Variable"
+  | "Spacing-Variable"
   | "Stroke-Fill-Style"
   | "Stroke-Fill-Variable"
   | "Text-Style";
@@ -111,7 +120,7 @@ export type LintCheckPercent = {
 };
 
 export type AggregateCountsCompliance = {
-  [key in "fills" | "rounding" | "strokes" | "text"]: {
+  [key in "fills" | "rounding" | "spacing" | "strokes" | "text"]: {
     attached: number;
     detached: number;
     none: number;

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -18,10 +18,12 @@ import checkTextMatch from "./textStyle";
 import {
   HexColorToFigmaVariableMap,
   RoundingToFigmaVariableMap,
+  SpacingToFigmaVariableMap,
 } from "../utils/variables";
 import checkFillVariableMatch from "./fillVariable";
 import checkStrokeVariableMatch from "./strokeVariable";
 import checkRoundingVariableMatch from "./roundingVariable";
+import checkSpacingVariableMatch from "./spacingVariable";
 
 /**
  * styleLookupMap - required for partial matches
@@ -31,6 +33,7 @@ export type LintCheckOptions = {
   styleLookupMap?: StyleLookupMap;
   hexColorToVariableMap?: HexColorToFigmaVariableMap;
   roundingToVariableMap?: RoundingToFigmaVariableMap;
+  spacingToVariableMap?: SpacingToFigmaVariableMap;
 };
 /**
  * Run through all partial matches, and make exceptions depending on rules
@@ -59,6 +62,7 @@ export const runSimilarityChecks = (
     checkFillVariableMatch,
     checkStrokeVariableMatch,
     checkRoundingVariableMatch,
+    checkSpacingVariableMatch,
   ];
 
   const results = [];
@@ -140,6 +144,17 @@ export const hasValidRoundingToMatch = (node: CornerMixin) => {
     rectangleCornerRadii.length > 0
   )
     return true;
+
+  return false;
+};
+
+export const hasValidSpacingToMatch = (node: CornerMixin) => {
+  const { layoutMode } = node as FrameNode;
+
+  // Spacing variables are only applicable when auto-layout is enabled
+  if (layoutMode === "HORIZONTAL" || layoutMode === "VERTICAL") {
+    return true;
+  }
 
   return false;
 };

--- a/src/rules/roundingVariable.ts
+++ b/src/rules/roundingVariable.ts
@@ -46,6 +46,7 @@ export default function checkRoundingVariableMatch(
       checkName,
       {}, // opts.hexColorToVariableMap not used in this check
       opts.roundingToVariableMap,
+      {}, // opts.spacingToVariableMap not used in this check
       "ROUNDING",
       targetNode
     );

--- a/src/rules/spacingVariable.ts
+++ b/src/rules/spacingVariable.ts
@@ -3,41 +3,33 @@ import { LintCheck, LintCheckName } from "../models/stats";
 
 import {
   LintCheckOptions,
-  hasValidFillToMatch,
+  hasValidSpacingToMatch,
   isNodeOfTypeAndVisible,
 } from ".";
 import { isExactVariableMatch } from "./utils/variables/exact";
 import getVariableLookupMatches from "./utils/variables/lookup";
 
-export default function checkFillVariableMatch(
+export default function checkSpacingVariableMatch(
   variables: FigmaLocalVariables,
   targetNode: BaseNode,
   opts?: LintCheckOptions
 ): LintCheck {
-  const checkName: LintCheckName = "Fill-Variable";
+  const checkName: LintCheckName = "Spacing-Variable";
 
-  // Check if correct Node Type
-  // REST API uses "REGULAR_POLYGON" but Figma uses "POLYGON"
+  // Check if correct Node Type. Only Frames and Instances can have spacing
   if (
     !isNodeOfTypeAndVisible(
-      ["ELLIPSE", "INSTANCE", "POLYGON", "REGULAR_POLYGON", "RECTANGLE", "STAR", "TEXT", "VECTOR"],
+      ["FRAME", "INSTANCE"],
       targetNode
     )
   )
     return { checkName, matchLevel: "Skip", suggestions: [] };
 
-  // Don't do variable processing if a fill style is in-use
-  if (
-    (targetNode as MinimalFillsMixin).fillStyleId ||
-    (targetNode as any).styles?.fill
-  )
-    return { checkName, matchLevel: "Skip", suggestions: [] };
-
-  if (!hasValidFillToMatch(targetNode as MinimalFillsMixin))
+  if (!hasValidSpacingToMatch(targetNode as BaseFrameMixin))
     return { checkName, matchLevel: "Skip", suggestions: [] };
 
   // check if variable is exact match
-  const exactMatch = isExactVariableMatch("FILL", variables, targetNode);
+  const exactMatch = isExactVariableMatch("SPACING", variables, targetNode);
 
   if (exactMatch)
     return {
@@ -48,13 +40,13 @@ export default function checkFillVariableMatch(
     };
 
   // Variable matching
-  if (opts?.hexColorToVariableMap) {
+  if (opts?.spacingToVariableMap) {
     const { matchLevel, suggestions } = getVariableLookupMatches(
       checkName,
-      opts.hexColorToVariableMap,
+      {}, // opts.hexColorToVariableMap not used in this check
       {}, // opts.roundingToVariableMap not used in this check
-      {}, // opts.spacingToVariableMap not used in this check
-      "FILL",
+      opts.spacingToVariableMap,
+      "SPACING",
       targetNode
     );
 

--- a/src/rules/strokeVariable.ts
+++ b/src/rules/strokeVariable.ts
@@ -53,6 +53,7 @@ export default function checkStrokeVariableMatch(
       checkName,
       opts.hexColorToVariableMap,
       {}, // opts.roundingToVariableMap not used in this check
+      {}, // opts.spacingToVariableMap not used in this check
       "STROKE",
       targetNode
     );

--- a/src/rules/utils/variables/exact.ts
+++ b/src/rules/utils/variables/exact.ts
@@ -1,8 +1,8 @@
 import { FigmaLocalVariable, FigmaLocalVariables } from "../../../models/figma";
-import { RadiusVariable } from "../../../models/stats";
+import { RadiusVariable, SpacingVariable } from "../../../models/stats";
 
 export const isExactVariableMatch = (
-  variableType: "FILL" | "ROUNDING" | "STROKE",
+  variableType: "FILL" | "ROUNDING" | "SPACING" | "STROKE",
   variables: FigmaLocalVariables,
   targetNode: BaseNode
 ): FigmaLocalVariable | undefined => {
@@ -106,9 +106,39 @@ export const isExactVariableMatch = (
           }
         });
 
-        // If they all match, return the first one
+        // If they all match, return the first one I guess?
         // :TODO: Do callers use this returned variable key?
         if (matchingVariables.length === 4) return matchingVariables[0];
+      }
+      break;
+
+    case "SPACING":
+      {
+        const matchingVariables: FigmaLocalVariable[] = [];
+        (
+          [
+            "counterAxisSpacing",
+            "itemSpacing",
+            "paddingBottom",
+            "paddingLeft",
+            "paddingRight",
+            "paddingTop",
+          ] as SpacingVariable[]
+        ).forEach((spacing) => {
+          const variableSubscribedId = (targetNode as FrameNode | InstanceNode).boundVariables?.[spacing]?.id;
+
+          if (variableSubscribedId) {
+            const variable = getVariableFromSubscribedId(variableSubscribedId);
+
+            if (variable && variable.scopes.includes("GAP")) {
+              matchingVariables.push(variable);
+            }
+          }
+        });
+
+        // If they all match, return the first one I guess?
+        // :TODO: Do callers use this returned variable key?
+        if (matchingVariables.length === 6) return matchingVariables[0];
       }
       break;
 

--- a/src/utils/process.ts
+++ b/src/utils/process.ts
@@ -46,51 +46,44 @@ export function getProcessedNodes(
   roundingVariableCollectionIds: string[],
   variables: FigmaLocalVariables,
   variableCollections: FigmaLocalVariableCollections,
-  opts?: ProcessedNodeOptions
+  opts: ProcessedNodeOptions
 ) {
   const styleBuckets = generateStyleBucket(allStyles);
   const styleLookupMap = generateStyleLookup(styleBuckets);
 
-  // Grab the variables from specific color variable collection(s)
-  let colorVariableIds: string[] = [];
-  let hexColorToVariableMap: HexColorToFigmaVariableMap = {};
-  if (
-    colorVariableCollectionIds.length > 0 &&
-    variables &&
-    Object.keys(variables).length > 0 &&
-    variableCollections &&
-    Object.keys(variableCollections).length > 0
-  ) {
-    colorVariableIds = getCollectionVariables(
-      colorVariableCollectionIds,
-      variableCollections
-    );
-    hexColorToVariableMap = createHexColorToVariableMap(
-      colorVariableIds,
-      variables,
-      variableCollections
-    );
-  }
+  let { hexColorToVariableMap, roundingToVariableMap } = opts;
 
-  // Grab the variables from specific rounding variable collection(s)
-  let roundingVariableIds: string[] = [];
-  let roundingToVariableMap: RoundingToFigmaVariableMap = {};
   if (
-    roundingVariableCollectionIds.length > 0 &&
     variables &&
     Object.keys(variables).length > 0 &&
     variableCollections &&
     Object.keys(variableCollections).length > 0
   ) {
-    roundingVariableIds = getCollectionVariables(
-      roundingVariableCollectionIds,
-      variableCollections
-    );
-    roundingToVariableMap = createRoundingToVariableMap(
-      roundingVariableIds,
-      variables,
-      variableCollections
-    );
+    // Create a map of hex colors to variables, if not passed
+    if (!hexColorToVariableMap && colorVariableCollectionIds.length > 0) {
+      const colorVariableIds = getCollectionVariables(
+        colorVariableCollectionIds,
+        variableCollections
+      );
+      hexColorToVariableMap = createHexColorToVariableMap(
+        colorVariableIds,
+        variables,
+        variableCollections
+      );
+    }
+
+    // Create a map of rounding values to variables, if not passed
+    if (!roundingToVariableMap && roundingVariableCollectionIds.length > 0) {
+      const roundingVariableIds = getCollectionVariables(
+        roundingVariableCollectionIds,
+        variableCollections
+      );
+      roundingToVariableMap = createRoundingToVariableMap(
+        roundingVariableIds,
+        variables,
+        variableCollections
+      );
+    }
   }
 
   const processedNodes: ProcessedNode[] = [];

--- a/src/utils/process.ts
+++ b/src/utils/process.ts
@@ -15,10 +15,9 @@ import {
 } from "../rules";
 import { makePercent } from "./percent";
 import {
-  HexColorToFigmaVariableMap,
-  RoundingToFigmaVariableMap,
   createHexColorToVariableMap,
   createRoundingToVariableMap,
+  createSpacingToVariableMap,
   getCollectionVariables,
 } from "./variables";
 
@@ -44,6 +43,7 @@ export function getProcessedNodes(
   allStyles: FigmaTeamStyle[],
   colorVariableCollectionIds: string[],
   roundingVariableCollectionIds: string[],
+  spacingVariableCollectionIds: string[],
   variables: FigmaLocalVariables,
   variableCollections: FigmaLocalVariableCollections,
   opts: ProcessedNodeOptions
@@ -51,7 +51,7 @@ export function getProcessedNodes(
   const styleBuckets = generateStyleBucket(allStyles);
   const styleLookupMap = generateStyleLookup(styleBuckets);
 
-  let { hexColorToVariableMap, roundingToVariableMap } = opts;
+  let { hexColorToVariableMap, roundingToVariableMap, spacingToVariableMap } = opts;
 
   if (
     variables &&
@@ -80,6 +80,19 @@ export function getProcessedNodes(
       );
       roundingToVariableMap = createRoundingToVariableMap(
         roundingVariableIds,
+        variables,
+        variableCollections
+      );
+    }
+
+    // Create a map of spacing values to variables, if not passed
+    if (!spacingToVariableMap && spacingVariableCollectionIds.length > 0) {
+      const spacingVariableIds = getCollectionVariables(
+        spacingVariableCollectionIds,
+        variableCollections
+      );
+      spacingToVariableMap = createSpacingToVariableMap(
+        spacingVariableIds,
         variables,
         variableCollections
       );
@@ -160,6 +173,7 @@ export function getProcessedNodes(
       styleLookupMap,
       hexColorToVariableMap,
       roundingToVariableMap,
+      spacingToVariableMap,
     });
 
     addToProcessedNodes({

--- a/src/utils/variables.test.ts
+++ b/src/utils/variables.test.ts
@@ -1,43 +1,233 @@
-import { rgbaToHex } from './variables';
+import {
+  createHexColorToVariableMap,
+  createRoundingToVariableMap,
+  createVariableMapVariable,
+  createVariableModeNameMap,
+  getCollectionVariables,
+  getModeValues,
+  isVariableAlias,
+  resolveVariableValue,
+  rgbaToHex,
+} from "./variables";
+import { FigmaLocalVariableCollections, FigmaLocalVariables } from "../models/figma";
+import variablesImported from "../../tests/__mocks__/variables.mock.json";
+import variableCollectionsImported from "../../tests/__mocks__/variableCollections.mock.json";
 
-describe('rgbaToHex', () => {
-  test('Converts color RGBA object to hex string', () => {
+const variables = variablesImported as FigmaLocalVariables;
+const variableCollections = variableCollectionsImported as FigmaLocalVariableCollections;
+
+describe("rgbaToHex", () => {
+  test("Converts color RGBA object to hex string", () => {
     const rgba: RGBA = {
       r: 0.8862745098039215,
       g: 0.07058823529411765,
       b: 0.06666666666666667,
       a: 1,
     };
-    expect(rgbaToHex(rgba)).toBe('#E21211FF');
+    expect(rgbaToHex(rgba)).toBe("#E21211FF");
   });
 
-  test('Converts white RGBA object to hex string', () => {
+  test("Converts white RGBA object to hex string", () => {
     const rgba: RGBA = {
       r: 1,
       g: 1,
       b: 1,
       a: 1,
     };
-    expect(rgbaToHex(rgba)).toBe('#FFFFFFFF');
+    expect(rgbaToHex(rgba)).toBe("#FFFFFFFF");
   });
 
-  test('Converts black RGBA object to hex string', () => {
+  test("Converts black RGBA object to hex string", () => {
     const rgba: RGBA = {
       r: 0,
       g: 0,
       b: 0,
       a: 1,
     };
-    expect(rgbaToHex(rgba)).toBe('#000000FF');
+    expect(rgbaToHex(rgba)).toBe("#000000FF");
   });
 
-  test('Converts half opacity RGBA object to hex string', () => {
+  test("Converts half opacity RGBA object to hex string", () => {
     const rgba: RGBA = {
       r: 0,
       g: 0,
       b: 0,
       a: 0.5,
     };
-    expect(rgbaToHex(rgba)).toBe('#00000080');
+    expect(rgbaToHex(rgba)).toBe("#00000080");
+  });
+});
+
+describe("isVariableAlias", () => {
+  test("Returns true if value is a VariableAlias", () => {
+    const variable = variables["VariableID:265:2997"].valuesByMode["265:0"];
+    expect(isVariableAlias(variable)).toBe(true);
+  });
+
+  test("Returns false if value is not a VariableAlias", () => {
+    const variable = variables["VariableID:7410:248"].valuesByMode["7410:0"];
+    expect(isVariableAlias(variable)).toBe(false);
+  });
+});
+
+describe("getCollectionVariables", () => {
+  test("Returns a list of variable ids in the collections", () => {
+    const variableCollectionIds = [
+      "VariableCollectionId:265:2989",
+      "VariableCollectionId:701:7994",
+      "VariableCollectionId:733:939",
+    ];
+    const variableIds = getCollectionVariables(variableCollectionIds, variableCollections);
+
+    expect(variableIds).toEqual(["VariableID:265:2997", "VariableID:701:7996", "VariableID:7410:308"]);
+  });
+});
+
+describe("resolveVariableValue", () => {
+  test("Resolves a variable value", () => {
+    const variableId = "VariableID:265:2997";
+    const modeId = "265:1";
+    const value = resolveVariableValue(variableId, modeId, variables, "COLOR");
+
+    expect(value).toEqual({ r: 0, g: 0, b: 0, a: 1 });
+  });
+});
+
+describe("createVariableModeNameMap", () => {
+  test("Creates a map of variable mode names", () => {
+    const map = createVariableModeNameMap(variableCollections);
+
+    expect(map).toEqual({
+      "265:0": "Light",
+      "265:1": "Dark",
+      "7410:2": "Default",
+      "7410:3": "Default",
+    });
+  });
+});
+
+describe("createVariableMapVariable", () => {
+  test("Creates a map of variable values", () => {
+    const variableId = "VariableID:265:2997";
+    const modeId = "265:1";
+    const variableModeNameMap = createVariableModeNameMap(variableCollections);
+
+    const variableMap = createVariableMapVariable(
+      variableId,
+      modeId,
+      variableModeNameMap,
+      variables,
+      variableCollections
+    );
+
+    expect(variableMap).toBeDefined();
+    expect(variableMap).toEqual({
+      name: "sema/color/background/default",
+      description: "",
+      variableId: "VariableID:265:2997",
+      variableKey: "b5210392296e696d0a8bb2f92aea2b1c3f4bfdb6",
+      variableCollectionId: "VariableCollectionId:265:2989",
+      variableCollectionKey: "4946b0f5dc6bdc872b0bc1ad0ad5e7f0a348e0ad",
+      variableCollectionName: "Colors",
+      variableCollectionDefaultModeId: "265:0",
+      modeId: "265:1",
+      modeName: "Dark",
+      scopes: ["FRAME_FILL", "SHAPE_FILL"],
+    });
+  });
+});
+
+describe("getModeValues", () => {
+  test("Returns a list of mode values", () => {
+    const variableId = "VariableID:265:2997";
+    const values = getModeValues(variableId, variables, "COLOR");
+
+    expect(values).toEqual([
+      {
+        variableId: "VariableID:265:2997",
+        modeId: "265:0",
+        value: {
+          r: 1,
+          g: 1,
+          b: 1,
+          a: 1,
+        },
+      },
+      {
+        variableId: "VariableID:265:2997",
+        modeId: "265:1",
+        value: {
+          r: 0,
+          g: 0,
+          b: 0,
+          a: 1,
+        },
+      },
+    ]);
+  });
+});
+
+describe("createHexColorToVariableMap", () => {
+  test("Creates a map of hex colors to variables", () => {
+    const colorVariableIds = getCollectionVariables(["VariableCollectionId:265:2989"], variableCollections);
+    const map = createHexColorToVariableMap(colorVariableIds, variables, variableCollections);
+
+    expect(map).toBeDefined();
+    expect(map).toEqual({
+      "#FFFFFFFF": [
+        {
+          name: "sema/color/background/default",
+          description: "",
+          variableId: "VariableID:265:2997",
+          variableKey: "b5210392296e696d0a8bb2f92aea2b1c3f4bfdb6",
+          variableCollectionId: "VariableCollectionId:265:2989",
+          variableCollectionKey: "4946b0f5dc6bdc872b0bc1ad0ad5e7f0a348e0ad",
+          variableCollectionName: "Colors",
+          variableCollectionDefaultModeId: "265:0",
+          modeId: "265:0",
+          modeName: "Light",
+          scopes: ["FRAME_FILL", "SHAPE_FILL"],
+        },
+      ],
+      "#000000FF": [
+        {
+          name: "sema/color/background/default",
+          description: "",
+          variableId: "VariableID:265:2997",
+          variableKey: "b5210392296e696d0a8bb2f92aea2b1c3f4bfdb6",
+          variableCollectionId: "VariableCollectionId:265:2989",
+          variableCollectionKey: "4946b0f5dc6bdc872b0bc1ad0ad5e7f0a348e0ad",
+          variableCollectionName: "Colors",
+          variableCollectionDefaultModeId: "265:0",
+          modeId: "265:1",
+          modeName: "Dark",
+          scopes: ["FRAME_FILL", "SHAPE_FILL"],
+        },
+      ],
+    });
+  });
+
+  test("Creates a map of rounding values to variables", () => {
+    const roundingVariableIds = getCollectionVariables(["VariableCollectionId:701:7994"], variableCollections);
+    const map = createRoundingToVariableMap(roundingVariableIds, variables, variableCollections);
+
+    expect(map).toBeDefined();
+    expect(map).toEqual({
+      "4": [
+        {
+          name: "sema/rounding/100",
+          description: "",
+          variableId: "VariableID:701:7996",
+          variableKey: "96b13ef45e11ceadb81ba0281b9e876c2b14d3dd",
+          variableCollectionId: "VariableCollectionId:701:7994",
+          variableCollectionKey: "454579e84c4e3d565bcc0262f5a81e28942222c8",
+          variableCollectionName: "Rounding",
+          variableCollectionDefaultModeId: "7410:2",
+          modeId: "7410:2",
+          modeName: "Default",
+          scopes: ["CORNER_RADIUS"],
+        },
+      ],
+    });
   });
 });

--- a/src/utils/variables.test.ts
+++ b/src/utils/variables.test.ts
@@ -1,6 +1,7 @@
 import {
   createHexColorToVariableMap,
   createRoundingToVariableMap,
+  createSpacingToVariableMap,
   createVariableMapVariable,
   createVariableModeNameMap,
   getCollectionVariables,
@@ -226,6 +227,30 @@ describe("createHexColorToVariableMap", () => {
           modeId: "7410:2",
           modeName: "Default",
           scopes: ["CORNER_RADIUS"],
+        },
+      ],
+    });
+  });
+
+  test("Creates a map of spacing values to variables", () => {
+    const spacingVariableIds = getCollectionVariables(["VariableCollectionId:733:939"], variableCollections);
+    const map = createSpacingToVariableMap(spacingVariableIds, variables, variableCollections);
+
+    expect(map).toBeDefined();
+    expect(map).toEqual({
+      "1": [
+        {
+          name: "sema/space/25",
+          description: "",
+          variableId: "VariableID:7410:308",
+          variableKey: "514b51e50626e605fc9d07668d22492e53c671dd",
+          variableCollectionId: "VariableCollectionId:733:939",
+          variableCollectionKey: "4e5f6934a1d3c0f5a8c815351342ff630b0bc069",
+          variableCollectionName: "Spacing",
+          variableCollectionDefaultModeId: "7410:3",
+          modeId: "7410:3",
+          modeName: "Default",
+          scopes: ["WIDTH_HEIGHT", "GAP"],
         },
       ],
     });

--- a/src/utils/variables.ts
+++ b/src/utils/variables.ts
@@ -16,6 +16,7 @@ export type FigmaVariableMapVariable = {
 
 export type HexColorToFigmaVariableMap = Record<string, FigmaVariableMapVariable[]>;
 export type RoundingToFigmaVariableMap = Record<number, FigmaVariableMapVariable[]>;
+export type SpacingToFigmaVariableMap = Record<number, FigmaVariableMapVariable[]>;
 
 type VariableModeValue = {
   variableId: string;

--- a/src/utils/variables.ts
+++ b/src/utils/variables.ts
@@ -14,20 +14,21 @@ export type FigmaVariableMapVariable = {
   scopes: VariableScope[];
 };
 
-export type HexColorToFigmaVariableMap = Record<
-  string,
-  FigmaVariableMapVariable[]
->;
+export type HexColorToFigmaVariableMap = Record<string, FigmaVariableMapVariable[]>;
+export type RoundingToFigmaVariableMap = Record<number, FigmaVariableMapVariable[]>;
 
-export type RoundingToFigmaVariableMap = Record<
-  number,
-  FigmaVariableMapVariable[]
->;
+type VariableModeValue = {
+  variableId: string;
+  modeId: string;
+  value: VariableValue;
+};
+
+type VariableModeMap = Record<string, string>;
 
 // Allow strictNullChecks to properly detect null filtering using a filter()
 const nonNullable = <T>(value: T): value is NonNullable<T> => {
   return Boolean(value);
-}
+};
 
 // Helper function to convert a RGBA object to a CSS hex string in the form of #RRGGBBAA
 export const rgbaToHex = (rgba: RGBA): string => {
@@ -43,7 +44,7 @@ export const rgbaToHex = (rgba: RGBA): string => {
 // Given a list of variable collection ids, return a list of variable ids in those collections
 export const getCollectionVariables = (
   variableCollectionIds: string[],
-  variableCollections: FigmaLocalVariableCollections,
+  variableCollections: FigmaLocalVariableCollections
 ): string[] => {
   return variableCollectionIds
     .map((collectionId) => {
@@ -58,17 +59,12 @@ export const isVariableAlias = (value: VariableValue): value is VariableAlias =>
 };
 
 // Take a variable id and mode id and return the typed-checked value, recursively resolving any variable aliases
-function resolveVariableValue (variableId: string, modeId: string, variables: FigmaLocalVariables, type: "BOOLEAN"): boolean | undefined;
-function resolveVariableValue (variableId: string, modeId: string, variables: FigmaLocalVariables, type: "FLOAT"): number | undefined;
-function resolveVariableValue (variableId: string, modeId: string, variables: FigmaLocalVariables, type: "STRING"): string | undefined;
-function resolveVariableValue (variableId: string, modeId: string, variables: FigmaLocalVariables, type: "COLOR"): RGBA | undefined;
-// Unhandled variable types
-function resolveVariableValue (variableId: string, modeId: string, variables: FigmaLocalVariables, type: "VARIABLE_ALIAS"): undefined;
-function resolveVariableValue (variableId: string, modeId: string, variables: FigmaLocalVariables, type: "EXPRESSION"): undefined;
-// Catch-all to handle typescript error when doing recursive calls to overloaded functions
-function resolveVariableValue (variableId: string, modeId: string, variables: FigmaLocalVariables, type: VariableDataType): VariableValue | undefined;
-// Implementation...
-function resolveVariableValue (variableId: string, modeId: string, variables: FigmaLocalVariables, type: VariableDataType): VariableValue | undefined {
+function resolveVariableValue(
+  variableId: string,
+  modeId: string,
+  variables: FigmaLocalVariables,
+  type: VariableDataType
+): VariableValue | undefined {
   const variable = variables[variableId];
   if (!variable) {
     console.log("WARNING: No value found for the matching mode:", variableId, modeId);
@@ -121,70 +117,114 @@ function resolveVariableValue (variableId: string, modeId: string, variables: Fi
 
   console.log("ERROR: The variable's value is not a VariableAlias or validated type:", type);
   return undefined;
-};
+}
 
-// #region Color Variables
-
-// Get the hex values for all of a variable's modes
-// ex: { variableId: "123", modeId: "456", hexValue: "#FFFFFF" }
-const getModeHexValues = (
-  variableId: string,
-  variables: FigmaLocalVariables,
-): Array<{
-  variableId: string;
-  modeId: string;
-  hexValue: string | undefined;
-}> | undefined => {
-  const variable = variables[variableId];
-
-  // Only include "COLOR" type variables that are not hidden from publishing and are not remote
-  if (!variable || variable.resolvedType !== "COLOR" || variable.hiddenFromPublishing || variable.remote) return undefined;
-
-  return Object.keys(variable.valuesByMode).map((modeId) => {
-    const color = resolveVariableValue(variableId, modeId, variables, "COLOR");
-    const hexValue = color ? rgbaToHex(color) : undefined;
-    return { variableId, modeId, hexValue };
-  });
-};
-
-// Group variables by their hex value
-export const createHexColorToVariableMap = (
-  colorVariableIds: string[],
-  variables: FigmaLocalVariables,
-  variableCollections: FigmaLocalVariableCollections,
-): HexColorToFigmaVariableMap => {
-  const variableHexValues = colorVariableIds
-    .map((variableId) => getModeHexValues(variableId, variables))
-    .filter(nonNullable)
-    .flat();
-
-  // Create a lookup map of mode ids to their names
-  const variableModeNameMap = Object.values(variableCollections).reduce<Record<string, string>>((acc, { modes }) => {
+// Create a lookup map of mode ids to their names
+const createVariableModeNameMap = (variableCollections: FigmaLocalVariableCollections): VariableModeMap => {
+  return Object.values(variableCollections).reduce<Record<string, string>>((acc, { modes }) => {
     modes.forEach(({ modeId, name }) => {
       acc[modeId] = name;
     });
     return acc;
   }, {});
+};
 
-  return variableHexValues.reduce<HexColorToFigmaVariableMap>((acc, { hexValue, variableId, modeId }) => {
-    if (hexValue) {
-      if (!acc[hexValue]) acc[hexValue] = [];
+// Given a variable id and mode id, create a FigmaVariableMapVariable object
+const createVariableMapVariable = (
+  variableId: string,
+  modeId: string,
+  variableModeNameMap: VariableModeMap,
+  variables: FigmaLocalVariables,
+  variableCollections: FigmaLocalVariableCollections
+): FigmaVariableMapVariable | undefined => {
+  const variable = variables[variableId];
+  if (!variable) return undefined;
 
-      const { name, description, key, variableCollectionId } = variables[variableId];
-      acc[hexValue].push({
-        name,
-        description,
-        variableId,
-        variableKey: key,
-        variableCollectionId,
-        variableCollectionKey: variableCollections[variableCollectionId].key,
-        variableCollectionName: variableCollections[variableCollectionId].name,
-        variableCollectionDefaultModeId: variableCollections[variableCollectionId].defaultModeId,
-        modeId,
-        modeName: variableModeNameMap[modeId],
-        scopes: variables[variableId].scopes,
-      });
-    }
+  const { name, description, key, scopes, variableCollectionId } = variable;
+
+  const variableCollection = variableCollections[variableCollectionId];
+  if (!variableCollection) return undefined;
+
+  const {
+    key: variableCollectionKey,
+    name: variableCollectionName,
+    defaultModeId: variableCollectionDefaultModeId,
+  } = variableCollection;
+
+  const modeName = variableModeNameMap[modeId];
+  if (!modeName) return undefined;
+
+  return {
+    name,
+    description,
+    variableId,
+    variableKey: key,
+    variableCollectionId,
+    variableCollectionKey,
+    variableCollectionName,
+    variableCollectionDefaultModeId,
+    modeId,
+    modeName,
+    scopes,
+  };
+};
+
+// Resolve the values for all of a variable's modes
+// ex: { variableId: "123", modeId: "456", value: 16 }
+const getModeValues = (
+  variableId: string,
+  variables: FigmaLocalVariables,
+  variableType: VariableDataType
+): VariableModeValue[] | undefined => {
+  const variable = variables[variableId];
+
+  // Only include variables of variableType, that are not hidden from publishing, and are not remote
+  if (!variable || variable.resolvedType !== variableType || variable.hiddenFromPublishing || variable.remote)
+    return undefined;
+
+  return Object.keys(variable.valuesByMode)
+    .map((modeId) => {
+      const value = resolveVariableValue(variableId, modeId, variables, variableType);
+
+      return value !== undefined ? { variableId, modeId, value } : undefined;
+    })
+    .filter(nonNullable);
+};
+
+// #region Color Variables
+
+// Group variables by their hex value
+export const createHexColorToVariableMap = (
+  colorVariableIds: string[],
+  variables: FigmaLocalVariables,
+  variableCollections: FigmaLocalVariableCollections
+): HexColorToFigmaVariableMap => {
+  const variableHexValues = colorVariableIds
+    .map((variableId) => getModeValues(variableId, variables, "COLOR"))
+    .filter(nonNullable)
+    .flat()
+    .map(({ variableId, modeId, value }) => ({
+      variableId,
+      modeId,
+      value: rgbaToHex(value as RGBA), // Convert the color value to a hex string
+    }));
+
+  // Create a lookup map of mode ids to their names
+  const variableModeNameMap = createVariableModeNameMap(variableCollections);
+
+  return variableHexValues.reduce<HexColorToFigmaVariableMap>((acc, { variableId, modeId, value }) => {
+    value = value as string; // Value is a hex string
+    if (!acc[value]) acc[value] = [];
+
+    const variableMapVariable = createVariableMapVariable(
+      variableId,
+      modeId,
+      variableModeNameMap,
+      variables,
+      variableCollections
+    );
+
+    if (variableMapVariable) acc[value].push(variableMapVariable);
 
     return acc;
   }, {});
@@ -193,66 +233,33 @@ export const createHexColorToVariableMap = (
 
 // #region: Rounding Variables
 
-// Get the rounding/radius values for all of a variable's modes
-// ex: { variableId: "123", modeId: "456", value: 16 }
-const getModeRoundingValues = (
-  variableId: string,
-  variables: FigmaLocalVariables,
-): Array<{
-  variableId: string;
-  modeId: string;
-  value: number | undefined;
-}> | undefined => {
-  const variable = variables[variableId];
-
-  // Only include "FLOAT" type variables that are not hidden from publishing and are not remote
-  if (!variable || variable.resolvedType !== "FLOAT" || variable.hiddenFromPublishing || variable.remote) return undefined;
-
-  return Object.keys(variable.valuesByMode).map((modeId) => {
-    const value = resolveVariableValue(variableId, modeId, variables, "FLOAT");
-    return { variableId, modeId, value };
-  });
-};
-
 // Group rounding variables by their radius value
 export const createRoundingToVariableMap = (
   roundingVariableIds: string[],
   variables: FigmaLocalVariables,
-  variableCollections: FigmaLocalVariableCollections,
+  variableCollections: FigmaLocalVariableCollections
 ): RoundingToFigmaVariableMap => {
   const variableRoundingValues = roundingVariableIds
-    .map((variableId) => getModeRoundingValues(variableId, variables))
+    .map((variableId) => getModeValues(variableId, variables, "FLOAT"))
     .filter(nonNullable)
     .flat();
 
   // Create a lookup map of mode ids to their names
-  const variableModeNameMap = Object.values(variableCollections).reduce<Record<string, string>>((acc, { modes }) => {
-    modes.forEach(({ modeId, name }) => {
-      acc[modeId] = name;
-    });
-    return acc;
-  }, {});
+  const variableModeNameMap = createVariableModeNameMap(variableCollections);
 
-  return variableRoundingValues.reduce<RoundingToFigmaVariableMap>((acc, { value, variableId, modeId }) => {
-    // if value exists
-    if (value !== undefined) {
-      if (!acc[value]) acc[value] = [];
+  return variableRoundingValues.reduce<RoundingToFigmaVariableMap>((acc, { variableId, modeId, value }) => {
+    value = value as number; // Rounding values are numbers
+    if (!acc[value]) acc[value] = [];
 
-      const { name, description, key, variableCollectionId } = variables[variableId];
-      acc[value].push({
-        name,
-        description,
-        variableId,
-        variableKey: key,
-        variableCollectionId,
-        variableCollectionKey: variableCollections[variableCollectionId].key,
-        variableCollectionName: variableCollections[variableCollectionId].name,
-        variableCollectionDefaultModeId: variableCollections[variableCollectionId].defaultModeId,
-        modeId,
-        modeName: variableModeNameMap[modeId],
-        scopes: variables[variableId].scopes,
-      });
-    }
+    const variableMapVariable = createVariableMapVariable(
+      variableId,
+      modeId,
+      variableModeNameMap,
+      variables,
+      variableCollections
+    );
+
+    if (variableMapVariable) acc[value].push(variableMapVariable);
 
     return acc;
   }, {});

--- a/src/utils/variables.ts
+++ b/src/utils/variables.ts
@@ -59,7 +59,7 @@ export const isVariableAlias = (value: VariableValue): value is VariableAlias =>
 };
 
 // Take a variable id and mode id and return the typed-checked value, recursively resolving any variable aliases
-function resolveVariableValue(
+export function resolveVariableValue(
   variableId: string,
   modeId: string,
   variables: FigmaLocalVariables,
@@ -120,7 +120,8 @@ function resolveVariableValue(
 }
 
 // Create a lookup map of mode ids to their names
-const createVariableModeNameMap = (variableCollections: FigmaLocalVariableCollections): VariableModeMap => {
+// Note: exporting for testing only
+export const createVariableModeNameMap = (variableCollections: FigmaLocalVariableCollections): VariableModeMap => {
   return Object.values(variableCollections).reduce<Record<string, string>>((acc, { modes }) => {
     modes.forEach(({ modeId, name }) => {
       acc[modeId] = name;
@@ -130,7 +131,8 @@ const createVariableModeNameMap = (variableCollections: FigmaLocalVariableCollec
 };
 
 // Given a variable id and mode id, create a FigmaVariableMapVariable object
-const createVariableMapVariable = (
+// Note: exported for testing only
+export const createVariableMapVariable = (
   variableId: string,
   modeId: string,
   variableModeNameMap: VariableModeMap,
@@ -171,7 +173,8 @@ const createVariableMapVariable = (
 
 // Resolve the values for all of a variable's modes
 // ex: { variableId: "123", modeId: "456", value: 16 }
-const getModeValues = (
+// Note: exported for testing only
+export const getModeValues = (
   variableId: string,
   variables: FigmaLocalVariables,
   variableType: VariableDataType

--- a/src/utils/variables.ts
+++ b/src/utils/variables.ts
@@ -269,3 +269,39 @@ export const createRoundingToVariableMap = (
 };
 
 // #endregion: Rounding Variables
+
+// #region: Spacing Variables
+
+// Group spacing variables by their value
+export const createSpacingToVariableMap = (
+  spacingVariableIds: string[],
+  variables: FigmaLocalVariables,
+  variableCollections: FigmaLocalVariableCollections
+): RoundingToFigmaVariableMap => {
+  const variableSpacingValues = spacingVariableIds
+    .map((variableId) => getModeValues(variableId, variables, "FLOAT"))
+    .filter(nonNullable)
+    .flat();
+
+  // Create a lookup map of mode ids to their names
+  const variableModeNameMap = createVariableModeNameMap(variableCollections);
+
+  return variableSpacingValues.reduce<RoundingToFigmaVariableMap>((acc, { variableId, modeId, value }) => {
+    value = value as number; // Spacing values are numbers
+    if (!acc[value]) acc[value] = [];
+
+    const variableMapVariable = createVariableMapVariable(
+      variableId,
+      modeId,
+      variableModeNameMap,
+      variables,
+      variableCollections
+    );
+
+    if (variableMapVariable) acc[value].push(variableMapVariable);
+
+    return acc;
+  }, {});
+};
+
+// #endregion: Spacing Variables

--- a/tests/__mocks__/variableCollections.mock.json
+++ b/tests/__mocks__/variableCollections.mock.json
@@ -1,0 +1,57 @@
+{
+  "VariableCollectionId:265:2989": {
+    "defaultModeId": "265:0",
+    "id": "VariableCollectionId:265:2989",
+    "name": "Colors",
+    "remote": false,
+    "modes": [
+      {
+        "modeId": "265:0",
+        "name": "Light"
+      },
+      {
+        "modeId": "265:1",
+        "name": "Dark"
+      }
+    ],
+    "key": "4946b0f5dc6bdc872b0bc1ad0ad5e7f0a348e0ad",
+    "hiddenFromPublishing": false,
+    "variableIds": [
+      "VariableID:265:2997"
+    ]
+  },
+  "VariableCollectionId:701:7994": {
+    "defaultModeId": "7410:2",
+    "id": "VariableCollectionId:701:7994",
+    "name": "Rounding",
+    "remote": false,
+    "modes": [
+      {
+        "modeId": "7410:2",
+        "name": "Default"
+      }
+    ],
+    "key": "454579e84c4e3d565bcc0262f5a81e28942222c8",
+    "hiddenFromPublishing": false,
+    "variableIds": [
+      "VariableID:701:7996"
+    ]
+  },
+  "VariableCollectionId:733:939": {
+    "defaultModeId": "7410:3",
+    "id": "VariableCollectionId:733:939",
+    "name": "Spacing",
+    "remote": false,
+    "modes": [
+      {
+        "modeId": "7410:3",
+        "name": "Default"
+      }
+    ],
+    "key": "4e5f6934a1d3c0f5a8c815351342ff630b0bc069",
+    "hiddenFromPublishing": false,
+    "variableIds": [
+      "VariableID:7410:308"
+    ]
+  }
+}

--- a/tests/__mocks__/variables.mock.json
+++ b/tests/__mocks__/variables.mock.json
@@ -1,0 +1,106 @@
+{
+  "VariableID:7410:248": {
+    "id": "VariableID:7410:248",
+    "name": "base/color/grayscale/0",
+    "remote": false,
+    "key": "433df2cc27341b6b7ec4f40c5f66ffa29d6b08cf",
+    "variableCollectionId": "VariableCollectionId:4995:2",
+    "resolvedType": "COLOR",
+    "description": "",
+    "hiddenFromPublishing": false,
+    "valuesByMode": {
+      "7410:0": {
+        "r": 1,
+        "g": 1,
+        "b": 1,
+        "a": 1
+      }
+    },
+    "scopes": [
+      "ALL_SCOPES"
+    ],
+    "codeSyntax": {}
+  },
+  "VariableID:7410:259": {
+    "id": "VariableID:7410:259",
+    "name": "base/color/grayscale/500",
+    "remote": false,
+    "key": "d2dea6c1a49faf51388ffa151f710055d5c2f4ae",
+    "variableCollectionId": "VariableCollectionId:4995:2",
+    "resolvedType": "COLOR",
+    "description": "",
+    "hiddenFromPublishing": false,
+    "valuesByMode": {
+      "7410:0": {
+        "r": 0,
+        "g": 0,
+        "b": 0,
+        "a": 1
+      }
+    },
+    "scopes": [
+      "ALL_SCOPES"
+    ],
+    "codeSyntax": {}
+  },
+  "VariableID:265:2997": {
+    "id": "VariableID:265:2997",
+    "name": "sema/color/background/default",
+    "remote": false,
+    "key": "b5210392296e696d0a8bb2f92aea2b1c3f4bfdb6",
+    "variableCollectionId": "VariableCollectionId:265:2989",
+    "resolvedType": "COLOR",
+    "description": "",
+    "hiddenFromPublishing": false,
+    "valuesByMode": {
+      "265:0": {
+        "type": "VARIABLE_ALIAS",
+        "id": "VariableID:7410:248"
+      },
+      "265:1": {
+        "type": "VARIABLE_ALIAS",
+        "id": "VariableID:7410:259"
+      }
+    },
+    "scopes": [
+      "FRAME_FILL",
+      "SHAPE_FILL"
+    ],
+    "codeSyntax": {}
+  },
+  "VariableID:701:7996": {
+    "id": "VariableID:701:7996",
+    "name": "sema/rounding/100",
+    "remote": false,
+    "key": "96b13ef45e11ceadb81ba0281b9e876c2b14d3dd",
+    "variableCollectionId": "VariableCollectionId:701:7994",
+    "resolvedType": "FLOAT",
+    "description": "",
+    "hiddenFromPublishing": false,
+    "valuesByMode": {
+      "7410:2": 4
+    },
+    "scopes": [
+      "CORNER_RADIUS"
+    ],
+    "codeSyntax": {}
+  },
+  "VariableID:7410:308": {
+    "id": "VariableID:7410:308",
+    "name": "sema/space/25",
+    "remote": false,
+    "key": "514b51e50626e605fc9d07668d22492e53c671dd",
+    "variableCollectionId": "VariableCollectionId:733:939",
+    "resolvedType": "FLOAT",
+    "description": "",
+    "hiddenFromPublishing": false,
+    "valuesByMode": {
+      "7410:3": 1
+    },
+    "scopes": [
+      "WIDTH_HEIGHT",
+      "GAP"
+    ],
+    "codeSyntax": {}
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -33,7 +33,7 @@
     "typeRoots": ["./node_modules/@types", "./node_modules/@figma"],
     // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
     // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
-    // "resolveJsonModule": true,                        /* Enable importing .json files */
+    "resolveJsonModule": true,                           /* Enable importing .json files */
     // "noResolve": true,                                /* Disallow `import`s, `require`s or `<reference>`s from expanding the number of files TypeScript should add to a project. */
 
     /* JavaScript Support */


### PR DESCRIPTION
## Summary
Adds support for matching and linting spacing variables.

Also refactored, improved, and added tests for the Variables helper library to make it easier to add spacing variable support.

## Development Notes
Spacing variable usage is only applicable for `FRAME` (and `INSTANCE`?) nodes with `layoutMode` = `HORIZONTAL` | `VERTICAL` (not `NONE`).

Spacing variables have the `GAP` scope.

Object parameters that can use spacing variables, and also the `boundVariables` property name:

- `itemSpacing` - For auto-layout frames with layoutMode set to `HORIZONTAL`, this is the horizontal gap between children. For auto-layout frames with layoutMode set to `VERTICAL`, this is the vertical gap between children.
- `counterAxisSpacing` - Applicable only on auto-layout frames with layoutWrap set to `WRAP`. Determines the distance between wrapped tracks.
- `paddingBottom`
- `paddingLeft`
- `paddingRight`
- `paddingTop`
- `horizontalPadding` - DEPRECATED: Use `paddingLeft` and `paddingRight` instead.
- `verticalPadding` - DEPRECATED: Use `paddingTop` and `paddingBottom` instead.

Note: The Plugin API also includes a `inferredAutoLayout property`, which has all those _except_ `counterAxisSpacing` for some reason.
