### PR TITLE
Update rules for exact spacing variable matching

### DIFF
--- a/src/rules/utils/variables/exact.ts
+++ b/src/rules/utils/variables/exact.ts
@@ -114,6 +114,8 @@ export const isExactVariableMatch = (
 
     case "SPACING":
       {
+        const node = targetNode as FrameNode | InstanceNode;
+
         const matchingVariables: FigmaLocalVariable[] = [];
         (
           [
@@ -125,7 +127,7 @@ export const isExactVariableMatch = (
             "paddingTop",
           ] as SpacingVariable[]
         ).forEach((spacing) => {
-          const variableSubscribedId = (targetNode as FrameNode | InstanceNode).boundVariables?.[spacing]?.id;
+          const variableSubscribedId = node.boundVariables?.[spacing]?.id;
 
           if (variableSubscribedId) {
             const variable = getVariableFromSubscribedId(variableSubscribedId);
@@ -137,8 +139,16 @@ export const isExactVariableMatch = (
         });
 
         // If they all match, return the first one I guess?
+        // Also match if there are only 5 bound variables with counterAxisSpacing unbound if the
+        // node is not a WRAP layout, because counterAxisSpacing is only used when Direction = WRAP
         // :TODO: Do callers use this returned variable key?
-        if (matchingVariables.length === 6) return matchingVariables[0];
+        if (
+          matchingVariables.length === 6 ||
+          (matchingVariables.length === 5 &&
+            node.layoutWrap !== "WRAP" &&
+            node.boundVariables?.["counterAxisSpacing"]?.id === undefined)
+        )
+          return matchingVariables[0];
       }
       break;
 


### PR DESCRIPTION
There are six spacing-related parameters that are currently being checked when measuring compliance:

```
counterAxisSpacing
itemSpacing
paddingBottom
paddingLeft
paddingRight
paddingTop
```

Sometimes `counterAxisSpacing` can be unset and not use a variable because the component instance isn't set to **Direction: Wrap**, which is the only time both `itemSpacing` and `counterAxisSpacing` input boxes are visible.
 
This PR improves the logic of the spacing token detection functionality:
* Only check if `counterAxisSpacing` is using a variable or not when the component instance is set to **Direction: Wrap**
 