### PR TITLE
Bug: Fix node filtering order

### DIFF
--- a/src/utils/process.ts
+++ b/src/utils/process.ts
@@ -109,28 +109,24 @@ export function getProcessedNodes(
     processedNodes.push(node);
   };
 
-  // find all the nodes in the document
+  // Find all the nodes in the document
   const allNodes = FigmaDocumentParser.FindAll(rootNode, (n) => true);
 
   let nonHiddenNonIgnoredNodes: BaseNode[] = [];
 
-  // toss any hidden nodes, get the counts
-  const { nonHiddenNodes, numHiddenLayers } =
-    FigmaCalculator.filterHiddenNodes(allNodes);
-    nonHiddenNonIgnoredNodes = nonHiddenNodes;
-
-  // toss any ignored component nodes
-  let nonIgnoredNodes: BaseNode[];
+  // Filter out any ignored component instance nodes first
+  let nonIgnoredNodes: BaseNode[] = allNodes;
   let numIgnoredLayers: number = 0;
   if (opts?.ignoredComponentKeys?.length) {
-    ({ nonIgnoredNodes, numIgnoredLayers } =
-      FigmaCalculator.filterIgnoredComponentNodes(
-        nonHiddenNodes,
-        opts?.ignoredComponentKeys
-      ));
-
-      nonHiddenNonIgnoredNodes = nonIgnoredNodes;
+    ({ nonIgnoredNodes, numIgnoredLayers } = FigmaCalculator.filterIgnoredComponentNodes(
+      allNodes,
+      opts.ignoredComponentKeys
+    ));
   }
+
+  // Filter any hidden nodes, get the count of hidden layers
+  const { nonHiddenNodes, numHiddenLayers } = FigmaCalculator.filterHiddenNodes(nonIgnoredNodes);
+  nonHiddenNonIgnoredNodes = nonHiddenNodes;
 
   // toss any library nodes from the list
   const { nonLibraryNodes, numLibraryNodes, libraryNodes } =


### PR DESCRIPTION
Ignored component instances might contain hidden layers, so filter those **before** hidden layers so they don't get counted twice and potentially cause adoption calculation errors. 

Here's an example of a calculation error presenting itself (fyi, "Outside of Gestalt" is the inverse of Adoption):

![Screenshot 2024-12-04 at 1 39 38 PM](https://github.com/user-attachments/assets/9aa15f21-b77c-4eea-919a-ad552d861365) 

> **125%** 🆗 😆

`Ignored component layers` + `Hidden layers` _should't_ be greater than the `Total Page layers`. 
