### PR TITLE
Allow ALL_SCOPES rounding and spacing variable matches

### DIFF
--- a/src/rules/utils/variables/exact.ts
+++ b/src/rules/utils/variables/exact.ts
@@ -79,7 +79,7 @@ export const isExactVariableMatch = (
 
         if (variableSubscribedId) {
           const variable = getVariableFromSubscribedId(variableSubscribedId);
-          if (variable && variable.scopes.includes("CORNER_RADIUS")) {
+          if (variable && (variable.scopes.includes("CORNER_RADIUS") || variable.scopes.includes("ALL_SCOPES"))) {
             return variable;
           }
         }
@@ -100,7 +100,7 @@ export const isExactVariableMatch = (
           if (variableSubscribedId) {
             const variable = getVariableFromSubscribedId(variableSubscribedId);
 
-            if (variable && variable.scopes.includes("CORNER_RADIUS")) {
+            if (variable && (variable.scopes.includes("CORNER_RADIUS") || variable.scopes.includes("ALL_SCOPES"))) {
               matchingVariables.push(variable);
             }
           }
@@ -132,7 +132,7 @@ export const isExactVariableMatch = (
           if (variableSubscribedId) {
             const variable = getVariableFromSubscribedId(variableSubscribedId);
 
-            if (variable && variable.scopes.includes("GAP")) {
+            if (variable && (variable.scopes.includes("GAP") || variable.scopes.includes("ALL_SCOPES"))) {
               matchingVariables.push(variable);
             }
           }


### PR DESCRIPTION
The code was expecting spacing variables to have the `GAP` scope, and rounding variables to have the `CORNER_RADIUS` scope, specifically set. This is not the case when a variable scope is set to "Show in all supported properties" in Figma. In that case we receive a `ALL_SCOPES` value.

Variables libraries in Figma sometimes \*cough\* have their scoping set incorrectly and/or inconsistently like this ("All" instead of more specific tighter scoping). This PR will make the code more resilient to those inconsistencies, though could lead to possible false positive matching via a variable being used outside of its implied scope (e.g. an incorrectly defined `ALL_SCOPES` spacing variable being used for a rounding value).

