### PR TITLE
GESTALT-8903: Disable Rounding and Spacing

### DIFF
--- a/src/rules/roundingVariable.ts
+++ b/src/rules/roundingVariable.ts
@@ -16,6 +16,9 @@ export default function checkRoundingVariableMatch(
 ): LintCheck {
   const checkName: LintCheckName = "Rounding-Variable";
 
+  // If we don't get a roundingToVariableMap, let's assume we should do any rounding checks at all
+  if (!opts?.roundingToVariableMap) return { checkName, matchLevel: "Skip", suggestions: [] };
+
   // Check if correct Node Type
   // REST API uses "REGULAR_POLYGON" but Figma uses "POLYGON"
   if (

--- a/src/rules/spacingVariable.ts
+++ b/src/rules/spacingVariable.ts
@@ -16,6 +16,9 @@ export default function checkSpacingVariableMatch(
 ): LintCheck {
   const checkName: LintCheckName = "Spacing-Variable";
 
+  // If we don't get a spacingToVariableMap, let's assume we should do any spacing checks at all
+  if (!opts?.spacingToVariableMap) return { checkName, matchLevel: "Skip", suggestions: [] };
+
   // Check if correct Node Type. Only Frames and Instances can have spacing
   if (
     !isNodeOfTypeAndVisible(


### PR DESCRIPTION
Allow for users to disable Rounding and Spacing checks completely by simply not passing the related variable map.