### PR TITLE
Bump 0.1.89-alpha

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "figma-calculations",
-  "version": "0.1.88-alpha",
+  "version": "0.1.89-alpha",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "figma-calculations",
-      "version": "0.1.88-alpha",
+      "version": "0.1.89-alpha",
       "license": "ISC",
       "dependencies": {
         "dayjs": "^1.11.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "figma-calculations",
-  "version": "0.1.88-alpha",
+  "version": "0.1.89-alpha",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
The version removed the `axios` package dependency. See: https://github.com/pinterest/figma-calculations/pull/51 for more details